### PR TITLE
[codex] 修复平台 Cookie 登录、CHZZK 清晰度和 SOOP 预览图

### DIFF
--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift
@@ -653,8 +653,12 @@ private struct PluginRoomDTO: Decodable {
         LiveModel(
             userName: userName,
             roomTitle: roomTitle,
-            roomCover: roomCover,
-            userHeadImg: userHeadImg,
+            roomCover: LiveImageURLResolver.roomCoverURLString(
+                rawValue: roomCover,
+                liveType: liveType,
+                roomId: roomId
+            ),
+            userHeadImg: LiveImageURLResolver.avatarURLString(rawValue: userHeadImg),
             liveType: liveType,
             liveState: liveState,
             userId: userId,

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift
@@ -395,6 +395,8 @@ private extension JSRuntime {
                 }
             }
 
+            var requestBody = envelope.body
+
             // 通用 cookieInject：从 cookie 取值注入到 header、query 或 body
             if !envelope.cookieInject.isEmpty {
                 var mutableURL = envelope.urlString
@@ -420,7 +422,7 @@ private extension JSRuntime {
                     case .body:
                         guard let bodyPath = rule.bodyPath else { continue }
                         if bodyJSON == nil {
-                            if let existing = request.httpBody,
+                            if let existing = requestBody,
                                let parsed = try? JSONSerialization.jsonObject(with: existing) as? [String: Any] {
                                 bodyJSON = parsed
                             } else {
@@ -436,7 +438,9 @@ private extension JSRuntime {
                     request.url = newURL
                 }
                 if let bodyJSON {
-                    request.httpBody = try? JSONSerialization.data(withJSONObject: bodyJSON)
+                    // Keep cookieInject body changes as the final request body.
+                    // Previously this was overwritten by envelope.body below.
+                    requestBody = try? JSONSerialization.data(withJSONObject: bodyJSON)
                 }
             }
 
@@ -444,7 +448,7 @@ private extension JSRuntime {
                 request.setValue(value, forHTTPHeaderField: key)
             }
 
-            request.httpBody = envelope.body
+            request.httpBody = requestBody
 
             // 开发者控制台：记录请求开始时间
             let httpStartTime = CFAbsoluteTimeGetCurrent()

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginManifest.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginManifest.swift
@@ -245,6 +245,6 @@ extension LiveParsePluginManifest {
 
     /// 该插件是否需要用户登录平台账号(用于安装前的凭证泄露风险确认)。
     public var requiresLogin: Bool {
-        (auth?.required == true) || (loginFlow != nil)
+        PlatformLoginCompatibility.requiresLogin(self)
     }
 }

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift
@@ -132,6 +132,32 @@ public enum RoomPlaybackResolver {
         return nil
     }
 
+    /// Selects the best initial playable item without trusting plugin order.
+    /// This protects platforms like CHZZK when a playlist contains `Auto` or
+    /// lower variants before the concrete 1080p/720p entries.
+    public static func preferredInitialSelection(in playArgs: [LiveQualityModel]?) -> RoomPlaybackSelection? {
+        guard let fallback = firstSelection(in: playArgs), let playArgs else { return nil }
+
+        var bestSelection: RoomPlaybackSelection?
+        var bestScore = Int.min
+
+        for (cdnIndex, cdn) in playArgs.enumerated() {
+            for (qualityIndex, quality) in cdn.qualitys.enumerated() {
+                guard isInitialPlaybackCandidate(quality) else { continue }
+                let score = initialQualityScore(quality)
+                guard score > bestScore else { continue }
+                bestScore = score
+                bestSelection = RoomPlaybackSelection(
+                    cdnIndex: cdnIndex,
+                    qualityIndex: qualityIndex,
+                    quality: quality
+                )
+            }
+        }
+
+        return bestSelection ?? fallback
+    }
+
     public static func firstSelection(
         in playArgs: [LiveQualityModel]?,
         where predicate: (LiveQualityDetail) -> Bool
@@ -421,5 +447,47 @@ public enum RoomPlaybackResolver {
         }
 
         return false
+    }
+
+    private static func initialQualityScore(_ quality: LiveQualityDetail) -> Int {
+        let title = quality.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if title.contains("audio") || title.contains("音频") {
+            return -1
+        }
+        if title.contains("auto") || title.contains("自适应") {
+            return 0
+        }
+        if title.contains("source") || title.contains("best") || title.contains("原画") {
+            return 10_000_000
+        }
+
+        let titleHeight = parsedHeight(from: title)
+        let qnScore = max(quality.qn, 0)
+        if titleHeight > 0 {
+            return titleHeight * 1_000 + min(qnScore, 999)
+        }
+        return qnScore
+    }
+
+    private static func isInitialPlaybackCandidate(_ quality: LiveQualityDetail) -> Bool {
+        let title = quality.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if title.contains("audio") || title.contains("音频") {
+            return false
+        }
+        return playableURL(for: quality) != nil || requiresRefreshOnSelect(quality)
+    }
+
+    private static func parsedHeight(from title: String) -> Int {
+        let pattern = #"(\d{3,4})\s*p"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return 0
+        }
+        let range = NSRange(title.startIndex..<title.endIndex, in: title)
+        guard let match = regex.firstMatch(in: title, options: [], range: range),
+              match.numberOfRanges >= 2,
+              let heightRange = Range(match.range(at: 1), in: title) else {
+            return 0
+        }
+        return Int(title[heightRange]) ?? 0
     }
 }

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift
@@ -1,0 +1,84 @@
+//
+//  CloudKitContainerAccess.swift
+//  AngelLiveCore
+//
+//  Centralized guard before touching CKContainer. Personal development
+//  profiles can install the app without iCloud entitlement; initializing a
+//  named CKContainer in that state traps before Swift can catch an error.
+//
+
+import CloudKit
+import Foundation
+
+enum CloudKitContainerAccess {
+    private static let iCloudContainerEntitlementKey = "com.apple.developer.icloud-container-identifiers"
+
+    static func privateDatabase(
+        containerIdentifier: String,
+        purpose: String,
+        category: LogCategory = .cloudKit
+    ) -> CKDatabase? {
+        guard hasICloudContainer(containerIdentifier) else {
+            Logger.info("当前签名未包含 iCloud entitlement，跳过\(purpose)", category: category)
+            return nil
+        }
+        return CKContainer(identifier: containerIdentifier).privateCloudDatabase
+    }
+
+    static func container(
+        identifier: String,
+        purpose: String,
+        category: LogCategory = .cloudKit
+    ) -> CKContainer? {
+        guard hasICloudContainer(identifier) else {
+            Logger.info("当前签名未包含 iCloud entitlement，跳过\(purpose)", category: category)
+            return nil
+        }
+        return CKContainer(identifier: identifier)
+    }
+
+    static func hasICloudContainer(_ identifier: String) -> Bool {
+        guard !identifier.isEmpty else { return false }
+
+        #if os(iOS) || os(tvOS)
+        guard let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision") else {
+            // App Store packages normally omit embedded.mobileprovision; trust the signed entitlement there.
+            return true
+        }
+        guard let entitlements = embeddedProvisioningEntitlements(at: url) else {
+            return false
+        }
+
+        if let containers = entitlements[iCloudContainerEntitlementKey] as? [String] {
+            return containers.contains(identifier)
+        }
+        if let container = entitlements[iCloudContainerEntitlementKey] as? String {
+            return container == identifier
+        }
+        return false
+        #else
+        return true
+        #endif
+    }
+
+    #if os(iOS) || os(tvOS)
+    /// Debug/AdHoc builds include a CMS mobileprovision file with an embedded plist.
+    private static func embeddedProvisioningEntitlements(at url: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: url),
+              let start = data.range(of: Data("<?xml".utf8)),
+              let end = data.range(of: Data("</plist>".utf8), in: start.lowerBound..<data.endIndex) else {
+            return nil
+        }
+
+        let plistData = Data(data[start.lowerBound..<end.upperBound])
+        guard let plist = try? PropertyListSerialization.propertyList(
+            from: plistData,
+            options: [],
+            format: nil
+        ) as? [String: Any] else {
+            return nil
+        }
+        return plist["Entitlements"] as? [String: Any]
+    }
+    #endif
+}

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/FavoriteService.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/FavoriteService.swift
@@ -21,8 +21,17 @@ private enum CloudFavoriteFields {
 }
 
 public final class FavoriteService: NSObject {
+    private static func cloudDatabase(purpose: String) -> CKDatabase? {
+        CloudKitContainerAccess.privateDatabase(
+            containerIdentifier: CloudFavoriteFields.containerIdentifier,
+            purpose: purpose,
+            category: .favorite
+        )
+    }
     
     public static func saveRecord(liveModel: LiveModel) async throws {
+        guard let database = cloudDatabase(purpose: "收藏 CloudKit 保存") else { return }
+
         let rec = CKRecord(recordType: "favorite_streamers")
         rec.setValue(liveModel.roomId, forKey: CloudFavoriteFields.roomId)
         rec.setValue(liveModel.userId, forKey: CloudFavoriteFields.userId)
@@ -32,12 +41,12 @@ public final class FavoriteService: NSObject {
         rec.setValue(liveModel.userHeadImg, forKey: CloudFavoriteFields.userHeadImage)
         rec.setValue(liveModel.liveType.rawValue, forKey: CloudFavoriteFields.liveType)
         rec.setValue(liveModel.liveState ?? "", forKey: CloudFavoriteFields.liveState)
-        try await CKContainer(identifier: CloudFavoriteFields.containerIdentifier).privateCloudDatabase.save(rec)
+        try await database.save(rec)
     }
     
     public static func searchRecord(roomId: String) async throws -> [LiveModel] {
-        let container = CKContainer(identifier: CloudFavoriteFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "收藏 CloudKit 查询") else { return [] }
+
         let predicate = NSPredicate(format: " \(CloudFavoriteFields.roomId) = '\(roomId)' ")
         let query = CKQuery(recordType: "favorite_streamers", predicate: predicate)
         // 使用新的 API
@@ -61,8 +70,8 @@ public final class FavoriteService: NSObject {
     }
     
     public static func searchRecord() async throws -> [LiveModel] {
-        let container = CKContainer(identifier: CloudFavoriteFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "收藏 CloudKit 列表查询") else { return [] }
+
         let query = CKQuery(recordType: "favorite_streamers", predicate: NSPredicate(value: true))
         // 使用新的 API
         let recordArray = try await database.records(matching: query, resultsLimit: 99999)
@@ -99,8 +108,8 @@ public final class FavoriteService: NSObject {
     }
     
     public static func deleteRecord(liveModel: LiveModel) async throws {
-        let container = CKContainer(identifier: CloudFavoriteFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "收藏 CloudKit 删除") else { return }
+
         let trimmedUserId = liveModel.userId.trimmingCharacters(in: .whitespacesAndNewlines)
         let predicate: NSPredicate
         if PlatformHostBehavior.favoriteIdentityKey(for: liveModel.liveType) == .userId, !trimmedUserId.isEmpty {
@@ -129,6 +138,9 @@ public final class FavoriteService: NSObject {
         guard !CloudFavoriteFields.containerIdentifier.isEmpty else {
             return "CloudKit 配置错误：容器标识符为空"
         }
+        guard CloudKitContainerAccess.hasICloudContainer(CloudFavoriteFields.containerIdentifier) else {
+            return "当前签名未包含 iCloud 权限，已跳过 iCloud 同步"
+        }
         
         // 2. 检查 CloudKit 可用性
         guard CKContainer.default().containerIdentifier != nil else {
@@ -141,7 +153,14 @@ public final class FavoriteService: NSObject {
             if CloudFavoriteFields.containerIdentifier == CKContainer.default().containerIdentifier {
                 container = CKContainer.default()
             } else {
-                container = CKContainer(identifier: CloudFavoriteFields.containerIdentifier)
+                guard let guardedContainer = CloudKitContainerAccess.container(
+                    identifier: CloudFavoriteFields.containerIdentifier,
+                    purpose: "CloudKit 状态检查",
+                    category: .favorite
+                ) else {
+                    return "当前签名未包含 iCloud 权限，已跳过 iCloud 同步"
+                }
+                container = guardedContainer
             }
             
             // 4. 添加超时保护

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Normalizes room image URLs before UI code hands them to Kingfisher.
+///
+/// Plugins should ideally return final absolute image URLs. This resolver keeps
+/// host-side compatibility for older plugin versions and saved records that may
+/// contain empty, scheme-relative, or legacy-domain image values.
+public enum LiveImageURLResolver {
+    public static func roomCoverURLString(
+        rawValue: String,
+        liveType: LiveType,
+        roomId: String
+    ) -> String {
+        let normalizedRaw = normalizedURLString(rawValue)
+        if !normalizedRaw.isEmpty {
+            return normalizedRaw
+        }
+
+        guard isSOOP(liveType), isNumericRoomId(roomId) else {
+            return ""
+        }
+
+        // SOOP sometimes omits thumbnails on authenticated/detail paths while
+        // the CDN still exposes previews deterministically by broad_no.
+        let fallback = "https://liveimg.sooplive.com/m/\(roomId)"
+        Logger.debug("[ImageResolver][SOOP] fallback=\(fallback)", category: .general)
+        return fallback
+    }
+
+    public static func avatarURLString(rawValue: String) -> String {
+        normalizedURLString(rawValue)
+    }
+
+    public static func normalizedURLString(_ rawValue: String) -> String {
+        var value = rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\\/", with: "/")
+
+        guard !value.isEmpty else { return "" }
+
+        if value.hasPrefix("//") {
+            value = "https:" + value
+        } else if !hasScheme(value),
+                  looksLikeHostPath(value) {
+            value = "https://" + value
+        }
+
+        guard var components = URLComponents(string: value) else {
+            return value
+        }
+
+        if components.scheme?.lowercased() == "http", isSOOPImageHost(components.host) {
+            components.scheme = "https"
+        }
+
+        if components.host?.lowercased() == "liveimg.sooplive.co.kr" {
+            components.host = "liveimg.sooplive.com"
+        }
+
+        return components.string ?? value
+    }
+
+    private static func hasScheme(_ value: String) -> Bool {
+        value.range(of: #"^[A-Za-z][A-Za-z0-9+\-.]*://"#, options: .regularExpression) != nil
+    }
+
+    private static func looksLikeHostPath(_ value: String) -> Bool {
+        guard let first = value.split(separator: "/", maxSplits: 1).first else {
+            return false
+        }
+        return first.contains(".")
+    }
+
+    private static func isSOOP(_ liveType: LiveType) -> Bool {
+        let raw = liveType.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw == "8" || raw == "soop"
+    }
+
+    private static func isSOOPImageHost(_ host: String?) -> Bool {
+        guard let host = host?.lowercased() else { return false }
+        return host == "liveimg.sooplive.com" || host == "liveimg.sooplive.co.kr"
+    }
+
+    private static func isNumericRoomId(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && trimmed.allSatisfy(\.isNumber)
+    }
+}
+
+public extension LiveModel {
+    var displayRoomCover: String {
+        LiveImageURLResolver.roomCoverURLString(
+            rawValue: roomCover,
+            liveType: liveType,
+            roomId: roomId
+        )
+    }
+
+    var displayUserHeadImg: String {
+        LiveImageURLResolver.avatarURLString(rawValue: userHeadImg)
+    }
+}

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Shared Cookie handling for platform login web views.
+///
+/// Some third-party platforms set auth cookies on sibling domains
+/// (`www.twitch.tv` vs `.twitch.tv`, `kick.com` vs `.kick.com`). Keeping the
+/// filtering and de-duplication rules here avoids iOS/macOS/tvOS drifting apart.
+public enum PlatformCookieCollector {
+    public static func filteredCookies(
+        from cookies: [HTTPCookie],
+        loginFlow: ManifestLoginFlow
+    ) -> [HTTPCookie] {
+        let hints = domainHints(for: loginFlow)
+        guard !hints.isEmpty else { return cookies }
+        return cookies.filter { cookie in
+            hints.contains { hint in
+                domainMatches(cookie.domain, hint: hint)
+            }
+        }
+    }
+
+    public static func containsAuthenticatedCookie(
+        in cookies: [HTTPCookie],
+        loginFlow: ManifestLoginFlow
+    ) -> Bool {
+        let names = Set(cookies.map(\.name))
+        return loginFlow.authSignalCookies.contains { names.contains($0) }
+    }
+
+    public static func cookieHeader(from cookies: [HTTPCookie]) -> String {
+        var bestByName: [String: HTTPCookie] = [:]
+        for cookie in cookies {
+            guard !cookie.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                continue
+            }
+            if let existing = bestByName[cookie.name] {
+                if isPreferredCookie(cookie, over: existing) {
+                    bestByName[cookie.name] = cookie
+                }
+            } else {
+                bestByName[cookie.name] = cookie
+            }
+        }
+
+        return bestByName.values
+            .sorted(by: cookieSort)
+            .map { "\($0.name)=\($0.value)" }
+            .joined(separator: "; ")
+    }
+
+    public static func signature(from cookies: [HTTPCookie]) -> String {
+        cookies
+            .sorted(by: cookieSort)
+            .map { "\($0.name)=\($0.value)" }
+            .joined(separator: ";")
+    }
+
+    public static func extractUID(
+        from cookies: [HTTPCookie],
+        loginFlow: ManifestLoginFlow
+    ) -> String? {
+        let uidNames = loginFlow.uidCookieNames ?? ["DedeUserID", "uid", "user_id", "userId"]
+        for name in uidNames {
+            if let value = cookies.first(where: { $0.name == name })?.value,
+               !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+
+    public static func domainHints(for loginFlow: ManifestLoginFlow) -> [String] {
+        var hints = loginFlow.cookieDomains
+        if let host = URL(string: loginFlow.loginURL)?.host {
+            hints.append(host)
+        }
+        if let host = loginFlow.websiteHost {
+            hints.append(host)
+        }
+        return Array(Set(hints.map(normalizedDomain).filter { !$0.isEmpty })).sorted()
+    }
+
+    public static func domainMatches(_ cookieDomain: String, hint: String) -> Bool {
+        let domain = normalizedDomain(cookieDomain)
+        let normalizedHint = normalizedDomain(hint)
+        guard !domain.isEmpty, !normalizedHint.isEmpty else { return false }
+
+        return domain == normalizedHint
+            || domain.hasSuffix("." + normalizedHint)
+            || normalizedHint.hasSuffix("." + domain)
+    }
+
+    public static func normalizedDomain(_ domain: String) -> String {
+        domain
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: ". "))
+    }
+
+    private static func isPreferredCookie(_ candidate: HTTPCookie, over current: HTTPCookie) -> Bool {
+        // Prefer active session cookies and more specific domains/paths when
+        // duplicate names appear on sibling domains during WebKit login.
+        let candidatePriority = cookiePriorityValues(candidate)
+        let currentPriority = cookiePriorityValues(current)
+
+        for index in candidatePriority.indices {
+            if candidatePriority[index] != currentPriority[index] {
+                return candidatePriority[index] > currentPriority[index]
+            }
+        }
+        return true
+    }
+
+    private static func cookiePriorityValues(_ cookie: HTTPCookie) -> [Int] {
+        [
+            cookie.value.isEmpty ? 0 : 1,
+            cookie.isSessionOnly ? 1 : 0,
+            normalizedDomain(cookie.domain).count,
+            cookie.path.count,
+            Int(cookie.expiresDate?.timeIntervalSince1970 ?? 0)
+        ]
+    }
+
+    private static func cookieSort(_ lhs: HTTPCookie, _ rhs: HTTPCookie) -> Bool {
+        if lhs.name != rhs.name {
+            return lhs.name < rhs.name
+        }
+        if lhs.domain != rhs.domain {
+            return lhs.domain < rhs.domain
+        }
+        return lhs.path < rhs.path
+    }
+}

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCredentialSyncService.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCredentialSyncService.swift
@@ -175,8 +175,9 @@ public final class PlatformCredentialSyncService: ObservableObject {
             result[pluginId] = session
         }
 
-        let container = CKContainer(identifier: CloudCookieFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "平台登录态 CloudKit 同步") else {
+            return
+        }
 
         // 获取现有所有 cloudRecord 的 pluginId 列表
         let allPluginIds = Set(sessionsByPluginId.keys)
@@ -222,8 +223,9 @@ public final class PlatformCredentialSyncService: ObservableObject {
         isSyncing = true
         defer { isSyncing = false }
 
-        let container = CKContainer(identifier: CloudCookieFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "平台登录态 CloudKit 拉取") else {
+            return
+        }
 
         await migrateLegacyCloudRecords(database: database)
 
@@ -271,8 +273,9 @@ public final class PlatformCredentialSyncService: ObservableObject {
     }
 
     public func fetchCloudSyncPreview() async -> ICloudSyncPreview {
-        let container = CKContainer(identifier: CloudCookieFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "平台登录态 CloudKit 预览") else {
+            return ICloudSyncPreview(latestTime: nil, platformNames: [])
+        }
 
         var latestDate: Date?
         var platformNames: [String] = []
@@ -303,8 +306,9 @@ public final class PlatformCredentialSyncService: ObservableObject {
         isSyncing = true
         defer { isSyncing = false }
 
-        let container = CKContainer(identifier: CloudCookieFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "平台登录态 CloudKit 清理") else {
+            return 0
+        }
         var recordIDsByName: [String: CKRecord.ID] = [:]
 
         let query = CKQuery(recordType: CloudCookieFields.recordType, predicate: NSPredicate(value: true))
@@ -567,8 +571,9 @@ public final class PlatformCredentialSyncService: ObservableObject {
         loggedInByPluginId[pluginId] = false
 
         if clearICloud {
-            let container = CKContainer(identifier: CloudCookieFields.containerIdentifier)
-            let database = container.privateCloudDatabase
+            guard let database = cloudDatabase(purpose: "平台登录态 CloudKit 删除") else {
+                return
+            }
             let recordName = CloudCookieFields.sessionRecordName(for: pluginId)
             let recordID = CKRecord.ID(recordName: recordName)
             do {
@@ -616,6 +621,14 @@ public final class PlatformCredentialSyncService: ObservableObject {
         let now = Date()
         lastICloudSyncTime = now
         UserDefaults.standard.set(now.timeIntervalSince1970, forKey: Keys.lastICloudSyncTime)
+    }
+
+    private func cloudDatabase(purpose: String) -> CKDatabase? {
+        CloudKitContainerAccess.privateDatabase(
+            containerIdentifier: CloudCookieFields.containerIdentifier,
+            purpose: purpose,
+            category: .cloudKit
+        )
     }
 
     /// 辅助类用于跟踪 Bonjour 发送状态

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Compatibility login declarations for older plugin manifests.
+///
+/// Twitch and Kick plugins already know how to consume host-managed cookies, but
+/// several released manifests do not declare `loginFlow`. Keep these fallbacks
+/// small and data-only so plugin authors can later move the same fields into
+/// manifest.json without changing app code.
+public enum PlatformLoginCompatibility {
+    public static func loginFlow(for manifest: LiveParsePluginManifest) -> ManifestLoginFlow? {
+        if let loginFlow = manifest.loginFlow {
+            return loginFlow
+        }
+
+        switch normalizedPluginId(manifest.pluginId) {
+        case "twitch":
+            return twitchLoginFlow()
+        case "kick":
+            return kickLoginFlow()
+        case "soop":
+            return soopLoginFlow()
+        default:
+            return nil
+        }
+    }
+
+    public static func auth(for manifest: LiveParsePluginManifest) -> ManifestAuth? {
+        if let auth = manifest.auth {
+            return auth
+        }
+        guard loginFlow(for: manifest) != nil else { return nil }
+        return ManifestAuth(
+            required: true,
+            credentialKinds: ["cookie"],
+            supportsStatusCheck: false,
+            supportsValidation: false
+        )
+    }
+
+    public static func requiresLogin(_ manifest: LiveParsePluginManifest) -> Bool {
+        if let required = manifest.auth?.required {
+            return required
+        }
+        return loginFlow(for: manifest) != nil
+    }
+
+    private static func twitchLoginFlow() -> ManifestLoginFlow {
+        ManifestLoginFlow(
+            kind: "webview",
+            loginURL: "https://www.twitch.tv/login",
+            cookieDomains: ["twitch.tv", "www.twitch.tv"],
+            authSignalCookies: ["auth-token"],
+            uidCookieNames: ["login", "name", "unique_id"],
+            successURLKeyword: "twitch.tv",
+            requiredCookieHint: "需要包含 auth-token，建议同时包含 login 或 unique_id。",
+            websiteHost: "www.twitch.tv"
+        )
+    }
+
+    private static func kickLoginFlow() -> ManifestLoginFlow {
+        ManifestLoginFlow(
+            kind: "webview",
+            loginURL: "https://kick.com/login",
+            cookieDomains: ["kick.com", "www.kick.com"],
+            authSignalCookies: ["kick_session", "XSRF-TOKEN"],
+            uidCookieNames: ["username", "user_id", "userId"],
+            successURLKeyword: "kick.com",
+            requiredCookieHint: "需要包含 kick_session，建议同时包含 XSRF-TOKEN。",
+            websiteHost: "kick.com"
+        )
+    }
+
+    private static func soopLoginFlow() -> ManifestLoginFlow {
+        ManifestLoginFlow(
+            kind: "webview",
+            loginURL: "https://login.sooplive.com/afreeca/login.php",
+            cookieDomains: [
+                "sooplive.co.kr",
+                "sooplive.com",
+                "afreecatv.com"
+            ],
+            authSignalCookies: [
+                "AuthTicket",
+                "PdboxTicket",
+                "RDB"
+            ],
+            uidCookieNames: ["uid", "user_id", "szBjId"],
+            successURLKeyword: "sooplive",
+            requiredCookieHint: "海外访问通常需要 AbroadChk=OK；19+ 房间还需要账号登录后的 AuthTicket/PdboxTicket 等 Cookie。",
+            websiteHost: "www.sooplive.com"
+        )
+    }
+
+    private static func normalizedPluginId(_ pluginId: String) -> String {
+        pluginId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginRegistry.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginRegistry.swift
@@ -52,7 +52,7 @@ public actor PlatformLoginRegistry {
         let manifests = discoverAllManifests()
         var entries: [LoginPlatformEntry] = []
         for manifest in manifests {
-            guard let loginFlow = manifest.loginFlow else { continue }
+            guard let loginFlow = PlatformLoginCompatibility.loginFlow(for: manifest) else { continue }
             let liveType = manifest.liveTypes.first ?? manifest.pluginId
             let displayName = manifest.displayName ?? manifest.pluginId
             let entry = LoginPlatformEntry(
@@ -60,7 +60,7 @@ public actor PlatformLoginRegistry {
                 displayName: displayName,
                 liveType: liveType,
                 loginFlow: loginFlow,
-                auth: manifest.auth,
+                auth: PlatformLoginCompatibility.auth(for: manifest),
                 version: manifest.version
             )
             entries.append(entry)

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceKeyService.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceKeyService.swift
@@ -30,9 +30,18 @@ public actor PluginSourceKeyService {
     /// 是否已成功加载过
     private var loaded = false
 
+    /// 内置兜底映射：keys.json 拉取失败时，官方订阅密钥仍可解析。
+    static let bundledFallbackKeyMap: [String: [String]] = [
+        "444222000": [
+            "https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/plugins.json",
+            "https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/plugins.json"
+        ]
+    ]
+
     /// 远程 keys.json 的备用地址（依次尝试）
     private let remoteURLs: [URL] = [
-        
+        URL(string: "https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json")!,
+        URL(string: "https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json")!
     ]
 
     private init() {}
@@ -44,6 +53,11 @@ public actor PluginSourceKeyService {
         // 已加载过则跳过
         guard !loaded else { return }
 
+        // 先放入稳定官方 key，远程成功后再覆盖/扩展。
+        if keyMap.isEmpty {
+            keyMap = Self.bundledFallbackKeyMap
+        }
+
         for url in remoteURLs {
             do {
                 let (data, response) = try await URLSession.shared.data(from: url)
@@ -52,7 +66,7 @@ public actor PluginSourceKeyService {
                     continue
                 }
                 let decoded = try JSONDecoder().decode(PluginSourceKeysResponse.self, from: data)
-                var map: [String: [String]] = [:]
+                var map = Self.bundledFallbackKeyMap
                 for entry in decoded.keys {
                     map[entry.key] = entry.urls
                 }
@@ -73,6 +87,6 @@ public actor PluginSourceKeyService {
     public func resolveKey(_ input: String) -> [String]? {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        return keyMap[trimmed]
+        return keyMap[trimmed] ?? Self.bundledFallbackKeyMap[trimmed]
     }
 }

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceSyncService.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceSyncService.swift
@@ -49,8 +49,14 @@ public final class PluginSourceSyncService {
 
     /// 将插件源 URL 列表同步到 CloudKit
     public static func syncToCloudStatic(sourceURLs: [String]) async {
-        let container = CKContainer(identifier: CloudPluginSourceFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = CloudKitContainerAccess.privateDatabase(
+            containerIdentifier: CloudPluginSourceFields.containerIdentifier,
+            purpose: "插件源 CloudKit 同步",
+            category: .plugin
+        ) else {
+            return
+        }
+
         let recordID = CKRecord.ID(recordName: CloudPluginSourceFields.fixedRecordName)
 
         if sourceURLs.isEmpty {
@@ -93,9 +99,16 @@ public final class PluginSourceSyncService {
             hasSyncedSources = false
             return
         }
+        guard let database = CloudKitContainerAccess.privateDatabase(
+            containerIdentifier: CloudPluginSourceFields.containerIdentifier,
+            purpose: "插件源 CloudKit 检查",
+            category: .plugin
+        ) else {
+            hasSyncedSources = false
+            syncedSourceURLs = []
+            return
+        }
 
-        let container = CKContainer(identifier: CloudPluginSourceFields.containerIdentifier)
-        let database = container.privateCloudDatabase
         let recordID = CKRecord.ID(recordName: CloudPluginSourceFields.fixedRecordName)
 
         do {

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/StreamBookmarkService.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/StreamBookmarkService.swift
@@ -100,11 +100,13 @@ public final class StreamBookmarkService {
 
     /// 从 CloudKit 同步到本地
     public func syncFromCloud() async {
+        guard let database = cloudDatabase else { return }
+
         isLoading = true
         defer { isLoading = false }
 
         do {
-            let cloudBookmarks = try await fetchAllFromCloud()
+            let cloudBookmarks = try await fetchAllFromCloud(database: database)
             bookmarks = cloudBookmarks.sorted { $0.addedAt > $1.addedAt }
             saveToCache()
             syncError = nil
@@ -115,11 +117,17 @@ public final class StreamBookmarkService {
 
     // MARK: - CloudKit 操作
 
-    private var database: CKDatabase {
-        CKContainer(identifier: CloudStreamBookmarkFields.containerIdentifier).privateCloudDatabase
+    private var cloudDatabase: CKDatabase? {
+        CloudKitContainerAccess.privateDatabase(
+            containerIdentifier: CloudStreamBookmarkFields.containerIdentifier,
+            purpose: "网络链接收藏 CloudKit 同步",
+            category: .cloudKit
+        )
     }
 
     private func saveToCloud(_ bookmark: StreamBookmark) async throws {
+        guard let database = cloudDatabase else { return }
+
         let record = CKRecord(recordType: CloudStreamBookmarkFields.recordType)
         record.setValue(bookmark.id, forKey: CloudStreamBookmarkFields.bookmarkId)
         record.setValue(bookmark.title, forKey: CloudStreamBookmarkFields.title)
@@ -132,6 +140,8 @@ public final class StreamBookmarkService {
     }
 
     private func deleteFromCloud(_ bookmark: StreamBookmark) async throws {
+        guard let database = cloudDatabase else { return }
+
         let predicate = NSPredicate(format: "%K = %@", CloudStreamBookmarkFields.bookmarkId, bookmark.id)
         let query = CKQuery(recordType: CloudStreamBookmarkFields.recordType, predicate: predicate)
         let results = try await database.records(matching: query)
@@ -146,7 +156,7 @@ public final class StreamBookmarkService {
         try await saveToCloud(bookmark)
     }
 
-    private func fetchAllFromCloud() async throws -> [StreamBookmark] {
+    private func fetchAllFromCloud(database: CKDatabase) async throws -> [StreamBookmark] {
         let query = CKQuery(recordType: CloudStreamBookmarkFields.recordType, predicate: NSPredicate(value: true))
         let results = try await database.records(matching: query, resultsLimit: 99999)
 

--- a/Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift
+++ b/Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift
@@ -171,6 +171,258 @@ struct PluginErrorCardParsingTests {
     }
 }
 
+@Suite("Plugin source keys")
+struct PluginSourceKeyTests {
+
+    @Test("Official short key resolves without remote key index")
+    func officialShortKeyFallback() async {
+        let urls = await PluginSourceKeyService.shared.resolveKey("444222000")
+
+        #expect(urls?.count == 2)
+        #expect(urls?.first?.contains("PluginRelease/plugins.json") == true)
+        #expect(urls?.first?.contains("ghfast.top") == true)
+    }
+}
+
+@Suite("Platform login compatibility")
+struct PlatformLoginCompatibilityTests {
+
+    @Test("Twitch and Kick older manifests get host login fallback")
+    func fallbackLoginFlows() {
+        let twitch = manifest(pluginId: "twitch", liveType: "9")
+        let kick = manifest(pluginId: "kick", liveType: "10")
+        let soop = manifest(pluginId: "soop", liveType: "8")
+
+        #expect(PlatformLoginCompatibility.loginFlow(for: twitch)?.authSignalCookies == ["auth-token"])
+        #expect(PlatformLoginCompatibility.loginFlow(for: kick)?.authSignalCookies.contains("kick_session") == true)
+        #expect(PlatformLoginCompatibility.loginFlow(for: soop)?.loginURL == "https://login.sooplive.com/afreeca/login.php")
+        #expect(PlatformLoginCompatibility.loginFlow(for: soop)?.cookieDomains.contains("sooplive.co.kr") == true)
+        #expect(PlatformLoginCompatibility.loginFlow(for: twitch)?.userAgent == nil)
+        #expect(PlatformLoginCompatibility.requiresLogin(twitch))
+        #expect(PlatformLoginCompatibility.requiresLogin(kick))
+        #expect(PlatformLoginCompatibility.requiresLogin(soop))
+    }
+
+    @Test("Manifest loginFlow wins over fallback")
+    func manifestLoginFlowWins() {
+        let declared = ManifestLoginFlow(
+            loginURL: "https://example.com/login",
+            cookieDomains: ["example.com"],
+            authSignalCookies: ["sid"]
+        )
+        let twitch = manifest(pluginId: "twitch", liveType: "9", loginFlow: declared)
+
+        #expect(PlatformLoginCompatibility.loginFlow(for: twitch)?.loginURL == "https://example.com/login")
+        #expect(PlatformLoginCompatibility.loginFlow(for: twitch)?.authSignalCookies == ["sid"])
+    }
+
+    @Test("Manifest auth required false wins over fallback loginFlow")
+    func manifestAuthRequiredFalseWins() {
+        let twitch = manifest(
+            pluginId: "twitch",
+            liveType: "9",
+            auth: ManifestAuth(required: false, credentialKinds: ["cookie"])
+        )
+
+        #expect(PlatformLoginCompatibility.loginFlow(for: twitch) != nil)
+        #expect(PlatformLoginCompatibility.requiresLogin(twitch) == false)
+    }
+}
+
+@Suite("Platform cookie collector")
+struct PlatformCookieCollectorTests {
+
+    @Test("Domain matching covers sibling login hosts")
+    func domainMatching() {
+        let loginFlow = ManifestLoginFlow(
+            loginURL: "https://www.twitch.tv/login",
+            cookieDomains: ["twitch.tv"],
+            authSignalCookies: ["auth-token"]
+        )
+        let cookies = [
+            cookie(name: "auth-token", value: "token", domain: ".twitch.tv"),
+            cookie(name: "login", value: "streamer", domain: "www.twitch.tv"),
+            cookie(name: "sid", value: "other", domain: "example.com")
+        ]
+
+        let filtered = PlatformCookieCollector.filteredCookies(from: cookies, loginFlow: loginFlow)
+        #expect(filtered.map(\.name).sorted() == ["auth-token", "login"])
+        #expect(PlatformCookieCollector.containsAuthenticatedCookie(in: filtered, loginFlow: loginFlow))
+        #expect(PlatformCookieCollector.cookieHeader(from: filtered).contains("auth-token=token"))
+    }
+
+    @Test("Session cookie wins duplicate header selection")
+    func sessionCookieWinsDuplicateHeaderSelection() {
+        let cookies = [
+            cookie(name: "XSRF-TOKEN", value: "old-persistent", domain: ".kick.com"),
+            cookie(name: "XSRF-TOKEN", value: "fresh-session", domain: "kick.com", expires: nil)
+        ]
+
+        #expect(PlatformCookieCollector.cookieHeader(from: cookies) == "XSRF-TOKEN=fresh-session")
+    }
+}
+
+@Suite("Live image URL resolver")
+struct LiveImageURLResolverTests {
+
+    @Test("SOOP empty cover falls back to live preview CDN by room id")
+    func soopEmptyCoverFallback() {
+        let cover = LiveImageURLResolver.roomCoverURLString(
+            rawValue: "",
+            liveType: LiveType(rawValue: "8")!,
+            roomId: "294060425"
+        )
+
+        #expect(cover == "https://liveimg.sooplive.com/m/294060425")
+    }
+
+    @Test("SOOP legacy image domain is canonicalized")
+    func soopLegacyDomainCanonicalized() {
+        let cover = LiveImageURLResolver.roomCoverURLString(
+            rawValue: "http://liveimg.sooplive.co.kr/m/294060425?511",
+            liveType: LiveType(rawValue: "8")!,
+            roomId: "294060425"
+        )
+
+        #expect(cover == "https://liveimg.sooplive.com/m/294060425?511")
+    }
+
+    @Test("Non-SOOP empty cover stays empty")
+    func nonSOOPEmptyCover() {
+        let cover = LiveImageURLResolver.roomCoverURLString(
+            rawValue: "",
+            liveType: LiveType(rawValue: "13")!,
+            roomId: "294060425"
+        )
+
+        #expect(cover.isEmpty)
+    }
+}
+
+@Suite("Playback initial selection")
+struct PlaybackInitialSelectionTests {
+
+    @Test("Prefers concrete CHZZK-like 1080p over Auto and lower variants")
+    func prefersHighestConcreteQuality() {
+        let playArgs = [
+            LiveQualityModel(cdn: "default", qualitys: [
+                quality(title: "Auto", qn: 0, url: "https://example.com/master.m3u8", liveType: "13"),
+                quality(title: "720p", qn: 720, url: "https://example.com/720.m3u8", liveType: "13"),
+                quality(title: "1080p", qn: 1080, url: "https://example.com/1080.m3u8", liveType: "13")
+            ])
+        ]
+
+        let selection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        #expect(selection?.qualityIndex == 2)
+        #expect(selection?.quality.title == "1080p")
+    }
+
+    @Test("Skips empty source placeholder when choosing initial stream")
+    func skipsEmptySourcePlaceholder() {
+        let playArgs = [
+            LiveQualityModel(cdn: "default", qualitys: [
+                quality(title: "原画", qn: 10_000, url: "", liveType: "13"),
+                quality(title: "1080p", qn: 1080, url: "https://example.com/1080.m3u8", liveType: "13")
+            ])
+        ]
+
+        let selection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        #expect(selection?.qualityIndex == 1)
+        #expect(selection?.quality.title == "1080p")
+    }
+
+    @Test("Skips audio-only stream when video stream is available")
+    func skipsAudioWhenVideoExists() {
+        let playArgs = [
+            LiveQualityModel(cdn: "default", qualitys: [
+                quality(title: "Audio", qn: 9999, url: "https://example.com/audio.m3u8", liveType: "13"),
+                quality(title: "720p", qn: 720, url: "https://example.com/720.m3u8", liveType: "13")
+            ])
+        ]
+
+        let selection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        #expect(selection?.qualityIndex == 1)
+        #expect(selection?.quality.title == "720p")
+    }
+
+    @Test("Allows refresh-only quality as initial stream candidate")
+    func allowsRefreshOnlyQualityCandidate() {
+        let playArgs = [
+            LiveQualityModel(cdn: "default", qualitys: [
+                quality(title: "720p", qn: 720, url: "https://example.com/720.m3u8", liveType: "13"),
+                quality(
+                    title: "原画",
+                    qn: 10_000,
+                    url: "",
+                    liveType: "13",
+                    playbackHints: LivePlaybackHints(selectionBehavior: .refreshOnSelect)
+                )
+            ])
+        ]
+
+        let selection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        #expect(selection?.qualityIndex == 1)
+        #expect(selection?.quality.title == "原画")
+    }
+}
+
+private func manifest(
+    pluginId: String,
+    liveType: String,
+    loginFlow: ManifestLoginFlow? = nil,
+    auth: ManifestAuth? = nil
+) -> LiveParsePluginManifest {
+    LiveParsePluginManifest(
+        pluginId: pluginId,
+        version: "1.0.0",
+        apiVersion: 1,
+        displayName: pluginId,
+        liveTypes: [liveType],
+        entry: "index.js",
+        auth: auth,
+        loginFlow: loginFlow
+    )
+}
+
+private func cookie(
+    name: String,
+    value: String,
+    domain: String,
+    expires: Date? = Date(timeIntervalSinceNow: 3600)
+) -> HTTPCookie {
+    var properties: [HTTPCookiePropertyKey: Any] = [
+        .name: name,
+        .value: value,
+        .domain: domain,
+        .path: "/"
+    ]
+    if let expires {
+        properties[.expires] = expires
+    }
+    return HTTPCookie(properties: properties)!
+}
+
+private func quality(
+    title: String,
+    qn: Int,
+    url: String,
+    liveType: String,
+    playbackHints: LivePlaybackHints? = nil
+) -> LiveQualityDetail {
+    LiveQualityDetail(
+        roomId: "room",
+        title: title,
+        qn: qn,
+        url: url,
+        liveCodeType: .hls,
+        liveType: LiveType(rawValue: liveType)!,
+        userAgent: nil,
+        headers: nil,
+        requestContext: nil,
+        playbackHints: playbackHints
+    )
+}
+
 private struct AnyCodingKey: CodingKey {
     let stringValue: String
     let intValue: Int?

--- a/Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift
+++ b/Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift
@@ -162,6 +162,12 @@ open class KSOptions {
     public var userAgent: String = "libmpv"
     public var avOptions: [String: Any] = [:]
     public var formatContextOptions: [String: Any] = [:]
+    public var playerTypes: [MediaPlayerProtocol.Type] = [
+        KSOptions.firstPlayerType,
+        KSOptions.secondPlayerType
+    ].compactMap { $0 }
+    public var videoFilters: [Any] = []
+    public var audioFilters: [Any] = []
     public var decodeType: KSDecodeType = .software
     public var canStartPictureInPictureAutomaticallyFromInline: Bool = false
 
@@ -353,6 +359,10 @@ public class KSPlayerLayerBase: NSObject {
 
     public func resetPlayer() {
         stop()
+    }
+
+    public func reset() {
+        resetPlayer()
     }
 
     public func select(subtitleInfo info: MediaPlayerTrack?) {

--- a/Shared/AngelLiveDependencies/Sources/PlayerOptions.swift
+++ b/Shared/AngelLiveDependencies/Sources/PlayerOptions.swift
@@ -4,7 +4,7 @@ import CoreMedia
 public class PlayerOptions: KSOptions, @unchecked Sendable {
     public var syncSystemRate: Bool = false
 
-    nonisolated required public init() {
+    nonisolated public required override init() {
         super.init()
     }
 

--- a/TV/AngelLiveTVOS/Source/DetailPlayer/DetailPlayerView.swift
+++ b/TV/AngelLiveTVOS/Source/DetailPlayer/DetailPlayerView.swift
@@ -58,7 +58,7 @@ struct DetailPlayerView: View {
             )
         } else if roomInfoViewModel.currentPlayURL == nil {
             ZStack {
-                KFImage(URL(string: roomInfoViewModel.currentRoom.roomCover))
+                KFImage(URL(string: roomInfoViewModel.currentRoom.displayRoomCover))
                     .resizable()
                     .scaledToFill()
                     .frame(width: 1920, height: 1080)

--- a/TV/AngelLiveTVOS/Source/DetailPlayer/PlayerControlCardView.swift
+++ b/TV/AngelLiveTVOS/Source/DetailPlayer/PlayerControlCardView.swift
@@ -27,7 +27,7 @@ struct PlayerControlCardView: View {
                 changeRoom(playControlCardViewModel.liveModel)
             } label: {
                 ZStack(alignment: .bottom) {
-                    KFImage(URL(string: playControlCardViewModel.liveModel.roomCover))
+                    KFImage(URL(string: playControlCardViewModel.liveModel.displayRoomCover))
                         .placeholder {
                             Image("placeholder")
                                 .resizable()
@@ -36,7 +36,7 @@ struct PlayerControlCardView: View {
                         .resizable()
                         .frame(width: 320, height: 210)
                         .blur(radius: 10)
-                    KFImage(URL(string: playControlCardViewModel.liveModel.roomCover))
+                    KFImage(URL(string: playControlCardViewModel.liveModel.displayRoomCover))
                         .placeholder {
                             Image("placeholder")
                                 .resizable()

--- a/TV/AngelLiveTVOS/Source/DetailPlayer/RoomInfoViewModel.swift
+++ b/TV/AngelLiveTVOS/Source/DetailPlayer/RoomInfoViewModel.swift
@@ -161,7 +161,10 @@ final class RoomInfoViewModel {
                 tappedSelection: tappedSelection,
                 effectiveSelection: tappedSelection
             )
-            currentPlayQualityString = currentQuality.title
+            currentPlayQualityString = RoomPlaybackResolver.qualityDisplayTitle(
+                in: playArgs,
+                selection: tappedSelection
+            )
             currentPlayQualityQn = currentQuality.qn
             self.currentCdnIndex = cdnIndex
             self.currentQualityIndex = urlIndex
@@ -177,7 +180,10 @@ final class RoomInfoViewModel {
             effectiveSelection: effectiveSelection
         )
 
-        currentPlayQualityString = effectiveQuality.title
+        currentPlayQualityString = RoomPlaybackResolver.qualityDisplayTitle(
+            in: playArgs,
+            selection: effectiveSelection ?? tappedSelection
+        )
         currentPlayQualityQn = effectiveQuality.qn
         self.currentCdnIndex = effectiveSelection?.cdnIndex ?? cdnIndex
         self.currentQualityIndex = effectiveSelection?.qualityIndex ?? urlIndex
@@ -407,7 +413,11 @@ final class RoomInfoViewModel {
             showToast(false, title: "获取直播间信息失败")
             return
         }
-        self.changePlayUrl(cdnIndex: 0, urlIndex: 0)
+        let initialSelection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        self.changePlayUrl(
+            cdnIndex: initialSelection?.cdnIndex ?? 0,
+            urlIndex: initialSelection?.qualityIndex ?? 0
+        )
         //开一个定时，检查主播是否已经下播
         if appViewModel.playerSettingsViewModel.openExitPlayerViewWhenLiveEnd == true {
             if PlatformHostBehavior.supportsLiveEndPolling(for: currentRoom.liveType) {

--- a/TV/AngelLiveTVOS/Source/List/LiveCardView.swift
+++ b/TV/AngelLiveTVOS/Source/List/LiveCardView.swift
@@ -68,7 +68,7 @@ struct LiveCardView: View {
             ZStack(alignment: .topLeading) {
                 ZStack(alignment: .bottom) {
                     // 背景模糊层
-                    KFImage(URL(string: currentLiveModel.roomCover))
+                    KFImage(URL(string: currentLiveModel.displayRoomCover))
                         .placeholder {
                             placeholderImage
                         }
@@ -79,7 +79,7 @@ struct LiveCardView: View {
                         .clipped()
 
                     // 前景封面图
-                    KFImage(URL(string: currentLiveModel.roomCover))
+                    KFImage(URL(string: currentLiveModel.displayRoomCover))
                         .onFailure { error in
                             print("Image loading failed: \(error)")
                         }
@@ -140,7 +140,7 @@ struct LiveCardView: View {
     private func streamerInfoSection(currentLiveModel: LiveModel) -> some View {
         HStack(spacing: 12) {
             // 主播头像
-            KFImage(URL(string: currentLiveModel.userHeadImg))
+            KFImage(URL(string: currentLiveModel.displayUserHeadImg))
                 .placeholder {
                     Circle()
                         .fill(Color.gray.opacity(0.3))

--- a/TV/TopShelfExtension/ContentProvider.swift
+++ b/TV/TopShelfExtension/ContentProvider.swift
@@ -180,10 +180,10 @@ class ContentProvider: TVTopShelfContentProvider {
             item.title = streamer.roomTitle + " - " + streamer.userName
 
             // 设置封面图片
-            if let coverURL = URL(string: streamer.roomCover) {
+            if let coverURL = URL(string: streamer.displayRoomCover) {
                 item.setImageURL(coverURL, for: .screenScale1x)
                 item.setImageURL(coverURL, for: .screenScale2x)
-            } else if let headURL = URL(string: streamer.userHeadImg) {
+            } else if let headURL = URL(string: streamer.displayUserHeadImg) {
                 item.setImageURL(headURL, for: .screenScale1x)
                 item.setImageURL(headURL, for: .screenScale2x)
             }

--- a/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
+++ b/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
@@ -1,0 +1,303 @@
+# SimpleLiveTVOS 修复变更说明（ops4.7 审查版）
+
+日期：2026-05-16
+
+## 审查范围
+
+本次修改围绕 3 个用户可见问题：
+
+- Twitch / Kick Cookie 登录无法稳定保存或无法出现在登录入口。
+- CHZZK 默认播放清晰度被降到 Auto / 低清晰度。
+- SOOP Cookie 登录后部分直播间没有预览图。
+- iOS 真机个人开发签名缺少 iCloud entitlement 时启动闪退。
+- 官方订阅密钥 `444222000` 未解析，误走普通视频收藏。
+
+同时修复代码审查发现的问题：
+
+- macOS 平台详情页登录入口把 `liveType` 当作 `pluginId` 传入，导致 SOOP 等平台登录页无法定位。
+- 初始清晰度选择可能选中空 URL 的“原画 / Best”占位项，导致播放器没有可播放地址。
+- ops4.7 复审后补修：音频轨不参与默认清晰度竞争、macOS Cookie 保存失败时登录状态置假、manifest 显式 `auth.required=false` 优先于宿主兜底、session Cookie 去重优先级、SOOP 兜底日志、tvOS 清晰度展示标题与 iOS/macOS 对齐。
+- 真机回归后补修：所有 CloudKit 入口在初始化 `CKContainer(identifier:)` 前先判断签名是否包含目标 iCloud 容器，避免个人开发证书无 iCloud 能力时启动或同步入口崩溃；订阅密钥服务补齐官方 `keys.json` 地址和 `444222000` 内置兜底。
+
+## 核心改动
+
+### 1. 平台登录兼容修复
+
+新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift`：
+
+- 为旧版 manifest 缺少 `loginFlow` 的平台提供宿主侧兼容声明。
+- 覆盖平台：`twitch`、`kick`、`soop`。
+- Twitch 登录 URL：`https://www.twitch.tv/login`。
+- Kick 登录 URL：`https://kick.com/login`。
+- SOOP 登录 URL：`https://login.sooplive.com/afreeca/login.php`。
+- SOOP Cookie 域覆盖 `sooplive.co.kr`、`sooplive.com`、`afreecatv.com`。
+
+修改 `LiveParsePluginManifest.requiresLogin`：
+
+- 由原先只看 manifest 原始字段，改为走 `PlatformLoginCompatibility.requiresLogin`。
+- 旧插件即使没有声明登录字段，也可以进入账号管理和登录流程。
+
+修改 `PlatformLoginRegistry`：
+
+- 使用兼容层返回的 `loginFlow` 和 `auth`。
+- 登录入口列表可包含 Twitch / Kick / SOOP 旧 manifest。
+
+修复 `macOS/AngelLiveMacOS/Views/PlatformDetailView.swift`：
+
+- 平台详情页登录弹窗改为传 `viewModel.platform.pluginId`。
+- 避免 `soop` 平台被错误传成 `8` 后查不到登录入口。
+
+### 2. Cookie 收集与 Web 登录修复
+
+新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`：
+
+- 统一 iOS / macOS 的 Cookie 过滤、去重、签名和 UID 提取逻辑。
+- 支持同站兄弟域匹配，例如 `.twitch.tv` / `www.twitch.tv`、`kick.com` / `www.kick.com`。
+- Cookie header 去重时优先非空、当前 session、域名和 path 更具体的 Cookie，再比较长有效期。
+
+修改 iOS 登录面板 `PlatformLoginWebSheet.swift`：
+
+- 使用 `PlatformCookieCollector.filteredCookies` 收集相关域名 Cookie。
+- 使用 `PlatformCookieCollector.cookieHeader` 生成最终 Cookie 字符串。
+- 使用 `PlatformCookieCollector.containsAuthenticatedCookie` 判断是否已登录。
+- 重新登录 / 退出登录时清理相关域名的 Cookie 和 WebKit 站点数据。
+- 登录 WebView 默认使用移动 Safari 风格 UA，不再让旧 Twitch/Kick/SOOP 兜底流强制注入桌面 Chromium UA，避免 Twitch 把 WKWebView 判定成“不支持的浏览器”。
+- 开启 `javaScriptCanOpenWindowsAutomatically`，并用 `WKUIDelegate` 接管 `target=_blank` / `window.open`，让 SOOP 的 Apple / Google 第三方登录按钮在当前 WebView 内继续跳转。
+
+修改 macOS 登录面板 `MacPlatformLoginWebSheet.swift`：
+
+- 同步 iOS 的统一 Cookie 收集逻辑。
+- 打开登录页时立即轮询一次 Cookie，避免登录完成后等待下一轮定时器。
+- “重新登录”和“退出登录”会清理相关平台网页登录缓存，避免旧账号 Cookie 干扰。
+- Cookie 保存返回过期、无效或网络错误时显式把 `isLoggedIn` 置为 `false`，避免 UI 留在“账号信息”页。
+- 登录 WebView 默认使用桌面 Safari 风格 UA，并同步处理第三方登录新窗口，保持 iOS / macOS 登录行为一致。
+
+### 3. JSRuntime Cookie 注入修复
+
+修改 `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift`：
+
+- 修复 `cookieInject` 写入 body 后又被 `envelope.body` 覆盖的问题。
+- 现在 body 注入结果会保留到最终请求。
+- 影响场景：插件需要把 Cookie 中的字段注入请求 body 时，之前会丢失。
+
+### 4. SOOP 直播间预览图修复
+
+新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift`：
+
+- 统一标准化直播间封面和头像 URL。
+- 支持：
+  - 去掉 JSON 转义中的 `\/`。
+  - `//host/path` 补 `https:`。
+  - `host/path` 补 `https://`。
+  - SOOP 旧图床域 `liveimg.sooplive.co.kr` 统一到 `liveimg.sooplive.com`。
+  - SOOP 图床 `http` 自动升级为 `https`。
+- 当 SOOP 房间 `roomCover` 为空且 `roomId` 是数字时，兜底生成：
+  - `https://liveimg.sooplive.com/m/{roomId}`
+- 命中 SOOP 兜底时输出 `[ImageResolver][SOOP] fallback=...` 调试日志，便于真机回归判断是否命中。
+
+修改 `LiveParseJSPlatformManager.PluginRoomDTO.toLiveModel`：
+
+- 插件返回的 `roomCover` 和 `userHeadImg` 在进入 `LiveModel` 前先做标准化。
+
+新增 `LiveModel` 展示扩展：
+
+- `displayRoomCover`
+- `displayUserHeadImg`
+
+所有 UI 图片加载改用展示扩展，避免旧缓存或未标准化 URL 继续导致图片失败。
+
+### 5. CHZZK 默认清晰度修复
+
+修改 `Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift`：
+
+- 新增 `preferredInitialSelection(in:)`。
+- 默认播放不再盲目使用插件返回的第一个清晰度。
+- 清晰度评分规则：
+  - `audio` / `音频` 最低。
+  - `auto` / `自适应` 低于明确分辨率。
+  - `source` / `best` / `原画` 最高。
+  - `1080p`、`720p` 等按解析出的高度排序。
+  - 没有高度时回退 `qn`。
+- 只在可直接播放或声明 `refreshOnSelect` 的清晰度中比较。
+- 避免空 URL 的“原画 / Best”占位项抢占默认播放。
+- 音频轨不会参与初始默认清晰度竞争；如果没有任何视频候选，仍保持旧逻辑的首项兜底。
+
+修改 iOS / tvOS / macOS 的 `RoomInfoViewModel`：
+
+- 初次拿到 `playArgs` 后使用 `preferredInitialSelection`。
+- 手动切换清晰度仍保留原有路径。
+- tvOS 展示当前清晰度时改用 `qualityDisplayTitle(in:selection:)`，同名不同流类型时和 iOS / macOS 一样追加 HLS / FLV 区分。
+
+### 6. VLC fallback 构建兼容
+
+当前默认 KSPlayer 依赖链会解析 `https://github.com/TracyPlayer/FFmpegKit`，该远端在本次验证时不可用。为了能在 Xcode 26.5 上完成本地编译验证，使用仓库已有的 `USE_VLC=1` fallback 路径。
+
+补齐 fallback 与真实 KSPlayer 的最小接口差异：
+
+- `Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift`
+  - `KSOptions.playerTypes`
+  - `KSOptions.videoFilters`
+  - `KSOptions.audioFilters`
+  - `KSPlayerLayerBase.reset()`
+- `Shared/AngelLiveDependencies/Sources/PlayerOptions.swift`
+  - `init()` 显式标记 `override`，兼容 fallback 下 `KSOptions` 的公开初始化器。
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift`
+  - 增加 `isLocked` 状态，和真实播放器模型对齐。
+
+### 7. 真机签名兼容与订阅密钥修复
+
+新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift`：
+
+- 在访问命名 CloudKit 容器前统一判断签名能力。
+- iOS / tvOS Debug 或 AdHoc 包通过 `embedded.mobileprovision` 读取 `com.apple.developer.icloud-container-identifiers`。
+- 如果当前签名没有 `iCloud.icloud.dev.igod.simplelive`，直接跳过对应 CloudKit 操作并输出日志。
+- App Store 包通常没有 `embedded.mobileprovision`，该路径仍信任正式签名 entitlement。
+
+接入该 guard 的 CloudKit 入口：
+
+- `FavoriteService`
+- `StreamBookmarkService`
+- `PluginSourceSyncService`
+- `PlatformCredentialSyncService`
+
+修复效果：
+
+- 个人开发团队不支持 iCloud / Push 的本地真机包可以正常启动。
+- 缺少 iCloud entitlement 时不再在 `CKContainer(identifier:)` 处触发 `EXC_BREAKPOINT / SIGTRAP`。
+- 本地收藏、插件安装、Cookie 登录仍可继续使用；仅跳过 iCloud 同步。
+
+修改 `PluginSourceKeyService`：
+
+- 补齐远程 `keys.json` 地址：
+  - `https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json`
+  - `https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json`
+- 增加官方密钥 `444222000` 的内置兜底映射。
+- 远程 keys 拉取失败时，`444222000` 仍会解析到官方插件索引，不会误当成普通视频地址。
+
+## 涉及文件
+
+### 新增文件
+
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift`
+- `docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md`
+
+### Shared / Core 修改
+
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginManifest.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginRegistry.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/FavoriteService.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCredentialSyncService.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceKeyService.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceSyncService.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/StreamBookmarkService.swift`
+- `Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift`
+
+### Shared / Dependencies 修改
+
+- `Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift`
+- `Shared/AngelLiveDependencies/Sources/PlayerOptions.swift`
+
+### iOS 修改
+
+- `iOS/AngelLive/AngelLive/FullUI/Components/LiveRoomCard.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Managers/NowPlayingManager.swift`
+- `iOS/AngelLive/AngelLive/FullUI/ViewModels/RoomInfoViewModel.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/DetailPlayerView.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerContainerView.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/VerticalLiveControllerView.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoSheet.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoView.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Setting/PlatformLoginWebSheet.swift`
+
+### tvOS 修改
+
+- `TV/AngelLiveTVOS/Source/DetailPlayer/DetailPlayerView.swift`
+- `TV/AngelLiveTVOS/Source/DetailPlayer/PlayerControlCardView.swift`
+- `TV/AngelLiveTVOS/Source/DetailPlayer/RoomInfoViewModel.swift`
+- `TV/AngelLiveTVOS/Source/List/LiveCardView.swift`
+- `TV/TopShelfExtension/ContentProvider.swift`
+
+### macOS 修改
+
+- `macOS/AngelLiveMacOS/ViewModels/RoomInfoViewModel.swift`
+- `macOS/AngelLiveMacOS/Views/MacPlatformLoginWebSheet.swift`
+- `macOS/AngelLiveMacOS/Views/PlatformDetailView.swift`
+- `macOS/AngelLiveMacOS/Views/PlayerControlView.swift`
+
+## 新增测试覆盖
+
+修改 `Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift`：
+
+- `PlatformLoginCompatibilityTests`
+  - 旧 Twitch / Kick / SOOP manifest 能获得宿主登录兜底。
+  - manifest 自带 `loginFlow` 时优先使用 manifest，不被兜底覆盖。
+- `PluginSourceKeyTests`
+  - 官方短密钥 `444222000` 不依赖远程 keys 索引也能解析到官方插件索引。
+- `PlatformCookieCollectorTests`
+  - 兄弟域 Cookie 能正确过滤。
+  - 登录信号 Cookie 能被识别。
+  - Cookie header 能正确生成。
+  - 同名 Cookie 去重时 session Cookie 优先于旧 persistent Cookie。
+- `LiveImageURLResolverTests`
+  - SOOP 空封面生成预览 CDN URL。
+  - SOOP 旧图床域名 canonicalize。
+  - 非 SOOP 空封面保持为空。
+- `PlaybackInitialSelectionTests`
+  - CHZZK 类 Auto / 720p / 1080p 列表默认选 1080p。
+  - 空 URL 的“原画”占位项不会被默认选中。
+  - 有视频候选时跳过 audio-only 音频轨。
+  - `refreshOnSelect` 的高画质项即使 URL 为空，仍允许作为初始候选。
+- `PlatformLoginCompatibilityTests`
+  - manifest 显式声明 `auth.required=false` 时优先于宿主 fallback。
+
+## 兼容性说明
+
+- 兼容层是 data-only，后续插件 manifest 正式声明 `loginFlow` 后，会自动优先使用 manifest 字段。
+- SOOP 预览图兜底只在 `liveType` 为 `8` 或 `soop`，且 `roomId` 为纯数字时启用。
+- UI 层保留原 `LiveModel.roomCover` / `userHeadImg` 字段，只新增展示用扩展，避免影响持久化模型结构。
+- 清晰度选择只改变初始默认项，用户手动切换清晰度流程未重写。
+
+## 验证结果
+
+已执行：
+
+```bash
+git diff --check
+swiftc -parse Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift macOS/AngelLiveMacOS/Views/PlatformDetailView.swift
+cd /tmp/SharedVerify/AngelLiveCore && swift test
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer USE_VLC=1 xcodebuild build -workspace AngelLive.xcworkspace -scheme AngelLive -configuration Debug -destination 'platform=iOS Simulator,id=82A4B971-5073-4823-9F79-4FC0C1427E7E' -skipPackagePluginValidation
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Shared/AngelLiveCore
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer USE_VLC=1 xcodebuild build -workspace AngelLive.xcworkspace -scheme AngelLive -configuration Debug -destination 'platform=iOS,id=00008130-000204881E6A001C' -allowProvisioningUpdates -skipPackagePluginValidation
+```
+
+结果：
+
+- `git diff --check` 通过。
+- 相关 Swift 文件语法解析通过。
+- 早期临时 SwiftPM 验证副本测试通过：`27 tests passed`。
+- iOS 模拟器 Debug 构建通过：`** BUILD SUCCEEDED **`。
+- Xcode 工具链直接运行 Core 测试通过：`28 tests passed`。
+- iOS 26.1 真机 Debug 构建通过：`** BUILD SUCCEEDED **`。
+
+真机状态：
+
+- Xcode 26.5 能识别已连接 iPhone 15 Pro，设备系统为 iOS 26.1，开发者模式已启用。
+- 使用本地测试 bundle id `com.anlonely.AngelLiveTest` 和个人开发团队完成真机安装。
+- 个人开发团队不支持 iCloud / Push，本地 Debug 包改用空 entitlement 验证；修复前启动在 `CKContainer(identifier:)` 崩溃，修复后可稳定进入 App。
+- iPhone Mirroring 实时验证：欢迎页、收藏页、配置页、设置页可打开。
+- 输入订阅密钥 `444222000` 后弹出订阅内容列表，并成功安装 14 个官方插件。
+- 设备容器确认已安装插件包含 `chzzk`、`kick`、`soop`、`twitch`，订阅源持久化为 `https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/plugins.json`。
+
+## 审查建议
+
+- 重点审查 `RoomPlaybackResolver.preferredInitialSelection` 是否符合 CHZZK 插件实际返回的 `playArgs` 结构。
+- 重点审查 `PlatformLoginCompatibility` 中 Twitch / Kick / SOOP 的 Cookie 名称和域名是否覆盖当前线上行为。
+- 重点审查 SOOP 兜底预览地址 `https://liveimg.sooplive.com/m/{roomId}` 在目标地区和网络环境下是否可访问。
+- 真机连接后建议验证 iOS 26.1 设备上的 WebKit 登录保存、播放器默认清晰度、SOOP 列表预览图三条主链路。

--- a/iOS/AngelLive/AngelLive/FullUI/Components/LiveRoomCard.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Components/LiveRoomCard.swift
@@ -74,12 +74,12 @@ struct LiveRoomCard: View {
     }
 
     private var coverURL: URL? {
-        guard !room.roomCover.isEmpty, let url = URL(string: room.roomCover) else { return nil }
+        guard !room.displayRoomCover.isEmpty, let url = URL(string: room.displayRoomCover) else { return nil }
         return url
     }
 
     private var avatarURL: URL? {
-        guard !room.userHeadImg.isEmpty, let url = URL(string: room.userHeadImg) else { return nil }
+        guard !room.displayUserHeadImg.isEmpty, let url = URL(string: room.displayUserHeadImg) else { return nil }
         return url
     }
 

--- a/iOS/AngelLive/AngelLive/FullUI/Managers/NowPlayingManager.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Managers/NowPlayingManager.swift
@@ -34,7 +34,7 @@ enum NowPlayingManager {
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
 
         // 异步加载封面图
-        loadArtwork(from: room.roomCover) { artwork in
+        loadArtwork(from: room.displayRoomCover) { artwork in
             if let artwork {
                 MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPMediaItemPropertyArtwork] = artwork
             }

--- a/iOS/AngelLive/AngelLive/FullUI/ViewModels/RoomInfoViewModel.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/ViewModels/RoomInfoViewModel.swift
@@ -134,7 +134,11 @@ final class RoomInfoViewModel {
             self.playErrorMessage = "暂无可用的播放源"
             return
         }
-        self.changePlayUrl(cdnIndex: 0, urlIndex: 0)
+        let initialSelection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        self.changePlayUrl(
+            cdnIndex: initialSelection?.cdnIndex ?? 0,
+            urlIndex: initialSelection?.qualityIndex ?? 0
+        )
 
         // 已成功获取到播放参数，标记已加载
         hasLoadedPlayURL = true

--- a/iOS/AngelLive/AngelLive/FullUI/Views/DetailPlayerView.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/DetailPlayerView.swift
@@ -342,7 +342,7 @@ struct DetailPlayerView: View {
     // MARK: - Background
 
     private var backgroundView: some View {
-        BlurredBackgroundView(imageURL: viewModel.currentRoom.userHeadImg)
+        BlurredBackgroundView(imageURL: viewModel.currentRoom.displayUserHeadImg)
             .edgesIgnoringSafeArea(.all)
     }
 

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerContainerView.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerContainerView.swift
@@ -400,7 +400,7 @@ struct PlayerContentView: View {
                     }
                 } else {
                     // 封面图作为背景
-                    KFImage(URL(string: viewModel.currentRoom.roomCover))
+                    KFImage(URL(string: viewModel.currentRoom.displayRoomCover))
                         .placeholder {
                             Rectangle()
                                 .fill(AppConstants.Colors.placeholderGradient())

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift
@@ -10,6 +10,7 @@ public final class KSVideoPlayerModel: ObservableObject {
     public var config: KSVideoPlayer.Coordinator
     public var options: KSOptions
     @Published public var url: URL?
+    @Published var isLocked = false
 
     public init(title: String, config: KSVideoPlayer.Coordinator, options: KSOptions, url: URL? = nil) {
         self.title = title

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/VerticalLiveControllerView.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/VerticalLiveControllerView.swift
@@ -114,7 +114,7 @@ struct VerticalLiveControllerView: View {
                     Button {
                         showStreamerInfo = true
                     } label: {
-                        KFAnimatedImage(URL(string: viewModel.currentRoom.userHeadImg))
+                        KFAnimatedImage(URL(string: viewModel.currentRoom.displayUserHeadImg))
                             .configure { view in
                                 view.framePreloadCount = 2
                             }

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoSheet.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoSheet.swift
@@ -56,7 +56,7 @@ struct StreamerInfoSheet: View {
     private var headerSection: some View {
         VStack(spacing: 12) {
             // 主播头像
-            if let avatarURL = URL(string: room.userHeadImg), !room.userHeadImg.isEmpty {
+            if let avatarURL = URL(string: room.displayUserHeadImg), !room.displayUserHeadImg.isEmpty {
                 KFAnimatedImage(avatarURL)
                     .configure { view in
                         view.framePreloadCount = 2

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoView.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoView.swift
@@ -76,7 +76,7 @@ struct StreamerInfoView: View {
                 Button {
                     showStreamerInfo = true
                 } label: {
-                    KFAnimatedImage(URL(string: viewModel.currentRoom.userHeadImg))
+                    KFAnimatedImage(URL(string: viewModel.currentRoom.displayUserHeadImg))
                         .configure { view in
                             view.framePreloadCount = 2
                         }

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Setting/PlatformLoginWebSheet.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Setting/PlatformLoginWebSheet.swift
@@ -240,17 +240,19 @@ struct PlatformLoginWebSheet: View {
         let loginFlow = entry.loginFlow
 
         currentWebView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
-            let filteredCookies = cookies.filter { cookie in
-                loginFlow.cookieDomains.contains { hint in
-                    cookie.domain.contains(hint)
-                }
-            }
+            let filteredCookies = PlatformCookieCollector.filteredCookies(
+                from: cookies,
+                loginFlow: loginFlow
+            )
 
-            let cookieString = makeCookieString(from: filteredCookies)
+            let cookieString = PlatformCookieCollector.cookieHeader(from: filteredCookies)
             guard !cookieString.isEmpty else { return }
-            guard containsAuthenticatedCookie(in: filteredCookies, loginFlow: loginFlow) else { return }
+            guard PlatformCookieCollector.containsAuthenticatedCookie(
+                in: filteredCookies,
+                loginFlow: loginFlow
+            ) else { return }
 
-            let signature = makeCookieSignature(from: filteredCookies)
+            let signature = PlatformCookieCollector.signature(from: filteredCookies)
 
             Task { @MainActor in
                 guard !isSavingCookie else { return }
@@ -271,7 +273,7 @@ struct PlatformLoginWebSheet: View {
         errorMessage = nil
         statusText = "检测到登录状态，正在保存..."
 
-        let uid = extractUID(from: cookies, loginFlow: entry.loginFlow)
+        let uid = PlatformCookieCollector.extractUID(from: cookies, loginFlow: entry.loginFlow)
         let shouldValidate = entry.auth?.supportsValidation ?? false
 
         let result = await PlatformSessionManager.shared.loginWithCookie(
@@ -309,41 +311,6 @@ struct PlatformLoginWebSheet: View {
         isSavingCookie = false
     }
 
-    // MARK: - Cookie 工具
-
-    private func containsAuthenticatedCookie(in cookies: [HTTPCookie], loginFlow: ManifestLoginFlow) -> Bool {
-        let names = Set(cookies.map(\.name))
-        return loginFlow.authSignalCookies.contains { names.contains($0) }
-    }
-
-    private func makeCookieSignature(from cookies: [HTTPCookie]) -> String {
-        cookies
-            .sorted(by: { $0.name < $1.name })
-            .map { "\($0.name)=\($0.value)" }
-            .joined(separator: ";")
-    }
-
-    private func makeCookieString(from cookies: [HTTPCookie]) -> String {
-        var deduplicated = [String: String]()
-        for cookie in cookies {
-            deduplicated[cookie.name] = cookie.value
-        }
-        return deduplicated
-            .sorted(by: { $0.key < $1.key })
-            .map { "\($0.key)=\($0.value)" }
-            .joined(separator: "; ")
-    }
-
-    private func extractUID(from cookies: [HTTPCookie], loginFlow: ManifestLoginFlow) -> String? {
-        let uidNames = loginFlow.uidCookieNames ?? ["DedeUserID", "uid", "user_id", "userId"]
-        for name in uidNames {
-            if let value = cookies.first(where: { $0.name == name })?.value, !value.isEmpty {
-                return value
-            }
-        }
-        return nil
-    }
-
     // MARK: - Actions
 
     private func prepareRelogin(entry: LoginPlatformEntry) async {
@@ -378,14 +345,14 @@ struct PlatformLoginWebSheet: View {
     @MainActor
     private func clearWebLoginData(for loginFlow: ManifestLoginFlow) async {
         let dataStore = WKWebsiteDataStore.default()
-        let domainHints = webDataDomainHints(for: loginFlow)
+        let domainHints = PlatformCookieCollector.domainHints(for: loginFlow)
         guard !domainHints.isEmpty else { return }
 
         await withCheckedContinuation { continuation in
             dataStore.httpCookieStore.getAllCookies { cookies in
                 let matchingCookies = cookies.filter { cookie in
                     domainHints.contains { hint in
-                        normalizedDomain(cookie.domain).contains(hint)
+                        PlatformCookieCollector.domainMatches(cookie.domain, hint: hint)
                     }
                 }
 
@@ -412,7 +379,7 @@ struct PlatformLoginWebSheet: View {
             dataStore.fetchDataRecords(ofTypes: dataTypes) { records in
                 let matchingRecords = records.filter { record in
                     domainHints.contains { hint in
-                        normalizedDomain(record.displayName).contains(hint)
+                        PlatformCookieCollector.domainMatches(record.displayName, hint: hint)
                     }
                 }
 
@@ -426,24 +393,6 @@ struct PlatformLoginWebSheet: View {
                 }
             }
         }
-    }
-
-    private func webDataDomainHints(for loginFlow: ManifestLoginFlow) -> [String] {
-        var hints = loginFlow.cookieDomains
-        if let host = URL(string: loginFlow.loginURL)?.host {
-            hints.append(host)
-        }
-        if let host = loginFlow.websiteHost {
-            hints.append(host)
-        }
-
-        return Array(Set(hints.map(normalizedDomain).filter { !$0.isEmpty }))
-    }
-
-    private func normalizedDomain(_ domain: String) -> String {
-        domain
-            .lowercased()
-            .trimmingCharacters(in: CharacterSet(charactersIn: ". "))
     }
 
     private func reloadLoginStatus() async {
@@ -481,13 +430,14 @@ private struct PlatformLoginWebView: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = WKWebsiteDataStore.default()
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
         webView.allowsBackForwardNavigationGestures = true
-        if let userAgent = loginFlow.userAgent {
-            webView.customUserAgent = userAgent
-        }
+        let userAgent = effectiveUserAgent
+        webView.customUserAgent = userAgent
 
         DispatchQueue.main.async {
             onWebViewCreated(webView)
@@ -495,9 +445,7 @@ private struct PlatformLoginWebView: UIViewRepresentable {
 
         if let url = URL(string: loginFlow.loginURL) {
             var request = URLRequest(url: url)
-            if let userAgent = loginFlow.userAgent {
-                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            }
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
             webView.load(request)
         }
         return webView
@@ -505,11 +453,45 @@ private struct PlatformLoginWebView: UIViewRepresentable {
 
     func updateUIView(_ uiView: WKWebView, context: Context) {}
 
-    final class Coordinator: NSObject, WKNavigationDelegate {
+    private var effectiveUserAgent: String {
+        let custom = loginFlow.userAgent?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let custom, !custom.isEmpty {
+            return custom
+        }
+        // Twitch 会拒绝不完整的 WKWebView UA；默认伪装成同内核的移动 Safari。
+        return "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1"
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         let onNavigationStateChange: (String?, URL?, Bool) -> Void
 
         init(onNavigationStateChange: @escaping (String?, URL?, Bool) -> Void) {
             self.onNavigationStateChange = onNavigationStateChange
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            if navigationAction.targetFrame == nil {
+                webView.load(navigationAction.request)
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            // SOOP/Apple/Google 登录常用 window.open；在当前 WebView 内接管，避免按钮无响应。
+            guard navigationAction.targetFrame == nil else { return nil }
+            webView.load(navigationAction.request)
+            return nil
         }
 
         func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {

--- a/macOS/AngelLiveMacOS/ViewModels/RoomInfoViewModel.swift
+++ b/macOS/AngelLiveMacOS/ViewModels/RoomInfoViewModel.swift
@@ -121,7 +121,11 @@ final class RoomInfoViewModel {
             self.playErrorMessage = "暂无可用的播放源"
             return
         }
-        self.changePlayUrl(cdnIndex: 0, urlIndex: 0)
+        let initialSelection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        self.changePlayUrl(
+            cdnIndex: initialSelection?.cdnIndex ?? 0,
+            urlIndex: initialSelection?.qualityIndex ?? 0
+        )
 
         // 已成功获取到播放参数，标记已加载
         hasLoadedPlayURL = true

--- a/macOS/AngelLiveMacOS/Views/MacPlatformLoginWebSheet.swift
+++ b/macOS/AngelLiveMacOS/Views/MacPlatformLoginWebSheet.swift
@@ -122,9 +122,7 @@ struct MacPlatformLoginWebSheet: View {
 
             Section {
                 Button("重新登录") {
-                    showWebView = true
-                    statusText = "请在网页中完成登录，系统会自动保存会话并由宿主托管鉴权。"
-                    errorMessage = nil
+                    Task { await prepareRelogin(entry: entry) }
                 }
             } footer: {
                 Text("Cookie 过期或切换账号时点这里，会打开登录页重新抓取。")
@@ -230,6 +228,7 @@ struct MacPlatformLoginWebSheet: View {
 
     private func startCookiePolling(entry: LoginPlatformEntry) {
         cookiePollingTimer?.invalidate()
+        pollCookieOnce(entry: entry)
         cookiePollingTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
             pollCookieOnce(entry: entry)
         }
@@ -240,17 +239,19 @@ struct MacPlatformLoginWebSheet: View {
         let loginFlow = entry.loginFlow
 
         currentWebView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
-            let filteredCookies = cookies.filter { cookie in
-                loginFlow.cookieDomains.contains { hint in
-                    cookie.domain.contains(hint)
-                }
-            }
+            let filteredCookies = PlatformCookieCollector.filteredCookies(
+                from: cookies,
+                loginFlow: loginFlow
+            )
 
-            let cookieString = makeCookieString(from: filteredCookies)
+            let cookieString = PlatformCookieCollector.cookieHeader(from: filteredCookies)
             guard !cookieString.isEmpty else { return }
-            guard containsAuthenticatedCookie(in: filteredCookies, loginFlow: loginFlow) else { return }
+            guard PlatformCookieCollector.containsAuthenticatedCookie(
+                in: filteredCookies,
+                loginFlow: loginFlow
+            ) else { return }
 
-            let signature = makeCookieSignature(from: filteredCookies)
+            let signature = PlatformCookieCollector.signature(from: filteredCookies)
 
             Task { @MainActor in
                 guard !isSavingCookie else { return }
@@ -267,7 +268,7 @@ struct MacPlatformLoginWebSheet: View {
         errorMessage = nil
         statusText = "检测到登录状态，正在保存..."
 
-        let uid = extractUID(from: cookies, loginFlow: entry.loginFlow)
+        let uid = PlatformCookieCollector.extractUID(from: cookies, loginFlow: entry.loginFlow)
         let shouldValidate = entry.auth?.supportsValidation ?? false
 
         let result = await PlatformSessionManager.shared.loginWithCookie(
@@ -290,12 +291,15 @@ struct MacPlatformLoginWebSheet: View {
             }
             await reloadLoginStatus()
         case .expired:
+            isLoggedIn = false
             statusText = "登录信息已过期"
             errorMessage = "Cookie 已过期，请重新登录。"
         case .invalid(let reason):
+            isLoggedIn = false
             statusText = "登录信息无效"
             errorMessage = reason
         case .networkError(let message):
+            isLoggedIn = false
             statusText = "网络错误"
             errorMessage = message
         }
@@ -303,48 +307,26 @@ struct MacPlatformLoginWebSheet: View {
         isSavingCookie = false
     }
 
-    // MARK: - Cookie 工具
-
-    private func containsAuthenticatedCookie(in cookies: [HTTPCookie], loginFlow: ManifestLoginFlow) -> Bool {
-        let names = Set(cookies.map(\.name))
-        return loginFlow.authSignalCookies.contains { names.contains($0) }
-    }
-
-    private func makeCookieSignature(from cookies: [HTTPCookie]) -> String {
-        cookies
-            .sorted(by: { $0.name < $1.name })
-            .map { "\($0.name)=\($0.value)" }
-            .joined(separator: ";")
-    }
-
-    private func makeCookieString(from cookies: [HTTPCookie]) -> String {
-        var deduplicated = [String: String]()
-        for cookie in cookies {
-            deduplicated[cookie.name] = cookie.value
-        }
-        return deduplicated
-            .sorted(by: { $0.key < $1.key })
-            .map { "\($0.key)=\($0.value)" }
-            .joined(separator: "; ")
-    }
-
-    private func extractUID(from cookies: [HTTPCookie], loginFlow: ManifestLoginFlow) -> String? {
-        let uidNames = loginFlow.uidCookieNames ?? ["DedeUserID", "uid", "user_id", "userId"]
-        for name in uidNames {
-            if let value = cookies.first(where: { $0.name == name })?.value, !value.isEmpty {
-                return value
-            }
-        }
-        return nil
-    }
-
     // MARK: - Actions
+
+    private func prepareRelogin(entry: LoginPlatformEntry) async {
+        statusText = "正在清理网页登录缓存..."
+        errorMessage = nil
+        lastSavedCookieSignature = nil
+        currentWebView = nil
+        await clearWebLoginData(for: entry.loginFlow)
+        showWebView = true
+        statusText = "请在网页中完成登录，系统会自动保存会话并由宿主托管鉴权。"
+    }
 
     private func logout() {
         Task {
             await syncService.clearSession(pluginId: pluginId)
             if syncService.iCloudSyncEnabled {
                 await syncService.syncAllToICloud()
+            }
+            if let entry {
+                await clearWebLoginData(for: entry.loginFlow)
             }
             await MainActor.run {
                 isLoggedIn = false
@@ -354,6 +336,59 @@ struct MacPlatformLoginWebSheet: View {
                 showWebView = false
                 statusText = "已退出登录"
                 errorMessage = nil
+            }
+        }
+    }
+
+    @MainActor
+    private func clearWebLoginData(for loginFlow: ManifestLoginFlow) async {
+        let dataStore = WKWebsiteDataStore.default()
+        let domainHints = PlatformCookieCollector.domainHints(for: loginFlow)
+        guard !domainHints.isEmpty else { return }
+
+        await withCheckedContinuation { continuation in
+            dataStore.httpCookieStore.getAllCookies { cookies in
+                let matchingCookies = cookies.filter { cookie in
+                    domainHints.contains { hint in
+                        PlatformCookieCollector.domainMatches(cookie.domain, hint: hint)
+                    }
+                }
+
+                guard !matchingCookies.isEmpty else {
+                    continuation.resume()
+                    return
+                }
+
+                let group = DispatchGroup()
+                for cookie in matchingCookies {
+                    group.enter()
+                    dataStore.httpCookieStore.delete(cookie) {
+                        group.leave()
+                    }
+                }
+                group.notify(queue: .main) {
+                    continuation.resume()
+                }
+            }
+        }
+
+        let dataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
+        await withCheckedContinuation { continuation in
+            dataStore.fetchDataRecords(ofTypes: dataTypes) { records in
+                let matchingRecords = records.filter { record in
+                    domainHints.contains { hint in
+                        PlatformCookieCollector.domainMatches(record.displayName, hint: hint)
+                    }
+                }
+
+                guard !matchingRecords.isEmpty else {
+                    continuation.resume()
+                    return
+                }
+
+                dataStore.removeData(ofTypes: dataTypes, for: matchingRecords) {
+                    continuation.resume()
+                }
             }
         }
     }
@@ -391,13 +426,14 @@ private struct MacPlatformLoginWebView: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = WKWebsiteDataStore.default()
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
         webView.allowsBackForwardNavigationGestures = true
-        if let userAgent = loginFlow.userAgent {
-            webView.customUserAgent = userAgent
-        }
+        let userAgent = effectiveUserAgent
+        webView.customUserAgent = userAgent
 
         DispatchQueue.main.async {
             onWebViewCreated(webView)
@@ -405,9 +441,7 @@ private struct MacPlatformLoginWebView: NSViewRepresentable {
 
         if let url = URL(string: loginFlow.loginURL) {
             var request = URLRequest(url: url)
-            if let userAgent = loginFlow.userAgent {
-                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            }
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
             webView.load(request)
         }
         return webView
@@ -415,11 +449,45 @@ private struct MacPlatformLoginWebView: NSViewRepresentable {
 
     func updateNSView(_ nsView: WKWebView, context: Context) {}
 
-    final class Coordinator: NSObject, WKNavigationDelegate {
+    private var effectiveUserAgent: String {
+        let custom = loginFlow.userAgent?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let custom, !custom.isEmpty {
+            return custom
+        }
+        // 保持 UA 与 WebKit 能力一致，避免 Twitch 等站点把登录页判成异常浏览器。
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15"
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         let onNavigationStateChange: (String?, URL?, Bool) -> Void
 
         init(onNavigationStateChange: @escaping (String?, URL?, Bool) -> Void) {
             self.onNavigationStateChange = onNavigationStateChange
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            if navigationAction.targetFrame == nil {
+                webView.load(navigationAction.request)
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            // 第三方登录按钮经常开新窗口；复用当前 WebView，Cookie 仍留在同一 dataStore。
+            guard navigationAction.targetFrame == nil else { return nil }
+            webView.load(navigationAction.request)
+            return nil
         }
 
         func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {

--- a/macOS/AngelLiveMacOS/Views/PlatformDetailView.swift
+++ b/macOS/AngelLiveMacOS/Views/PlatformDetailView.swift
@@ -26,9 +26,9 @@ struct PlatformDetailView: View {
         return "加载失败-请登录\(platformName)账号"
     }
 
-    /// 根据平台类型显示对应的登录视图
+    /// 平台登录注册表按 pluginId 建索引，不能用 liveType rawValue。
     private var platformLoginView: some View {
-        MacPlatformLoginWebSheet(pluginId: viewModel.platform.liveType.rawValue)
+        MacPlatformLoginWebSheet(pluginId: viewModel.platform.pluginId)
             .frame(minWidth: 800, minHeight: 600)
     }
 
@@ -407,7 +407,7 @@ struct LiveRoomCard: View {
 //    }
 
     private var coverURL: URL? {
-        guard !room.roomCover.isEmpty, let url = URL(string: room.roomCover) else { return nil }
+        guard !room.displayRoomCover.isEmpty, let url = URL(string: room.displayRoomCover) else { return nil }
         return url
     }
 
@@ -437,7 +437,7 @@ struct LiveRoomCard: View {
                 .clipShape(RoundedRectangle(cornerRadius: AppConstants.CornerRadius.lg))
 
             HStack(spacing: 8) {
-                RemoteAvatarView(url: URL(string: room.userHeadImg), size: 32) {
+                RemoteAvatarView(url: URL(string: room.displayUserHeadImg), size: 32) {
                     Circle()
                         .fill(Color.gray.opacity(0.3))
                 }

--- a/macOS/AngelLiveMacOS/Views/PlayerControlView.swift
+++ b/macOS/AngelLiveMacOS/Views/PlayerControlView.swift
@@ -385,7 +385,7 @@ struct PlayerControlView: View {
     private var streamerInfoCard: some View {
         HStack(spacing: 10) {
             // 主播头像
-            RemoteAvatarView(url: URL(string: room.userHeadImg), size: 36) {
+            RemoteAvatarView(url: URL(string: room.displayUserHeadImg), size: 36) {
                 Circle()
                     .fill(Color.gray.opacity(0.3))
             }


### PR DESCRIPTION
# SimpleLiveTVOS 修复变更说明（ops4.7 审查版）

日期：2026-05-16

## 审查范围

本次修改围绕 3 个用户可见问题：

- Twitch / Kick Cookie 登录无法稳定保存或无法出现在登录入口。
- CHZZK 默认播放清晰度被降到 Auto / 低清晰度。
- SOOP Cookie 登录后部分直播间没有预览图。
- SOOP 19x 直播间返回灰色年龄占位图，登录后仍缺少真实实时封面。
- iOS 真机 SOOP 19x 播放页左键点击不弹控制层、画面闪烁或卡死。
- iOS 真机个人开发签名缺少 iCloud entitlement 时启动闪退。
- 官方订阅密钥 `444222000` 未解析，误走普通视频收藏。

同时修复代码审查发现的问题：

- macOS 平台详情页登录入口把 `liveType` 当作 `pluginId` 传入，导致 SOOP 等平台登录页无法定位。
- 初始清晰度选择可能选中空 URL 的“原画 / Best”占位项，导致播放器没有可播放地址。
- ops4.7 复审后补修：音频轨不参与默认清晰度竞争、macOS Cookie 保存失败时登录状态置假、manifest 显式 `auth.required=false` 优先于宿主兜底、session Cookie 去重优先级、SOOP 兜底日志、tvOS 清晰度展示标题与 iOS/macOS 对齐。
- 真机回归后补修：所有 CloudKit 入口在初始化 `CKContainer(identifier:)` 前先判断签名是否包含目标 iCloud 容器，避免个人开发证书无 iCloud 能力时启动或同步入口崩溃；订阅密钥服务补齐官方 `keys.json` 地址和 `444222000` 内置兜底。
- SOOP 19x 复测后补修：只对 19x 占位封面做一次实时截图缓存，非 19x 房间不再 force refresh；首次进入 SOOP 拉取前三页并预热 19x 截图，滚动时继续按窗口预加载未处理过的 19x 房间。

## 核心改动

### 1. 平台登录兼容修复

新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift`：

- 为旧版 manifest 缺少 `loginFlow` 的平台提供宿主侧兼容声明。
- 覆盖平台：`twitch`、`kick`、`soop`。
- Twitch 登录 URL：`https://www.twitch.tv/login`。
- Kick 登录 URL：`https://kick.com/login`。
- SOOP 登录 URL：`https://login.sooplive.com/afreeca/login.php`。
- SOOP Cookie 域覆盖 `sooplive.co.kr`、`sooplive.com`、`afreecatv.com`。

修改 `LiveParsePluginManifest.requiresLogin`：

- 由原先只看 manifest 原始字段，改为走 `PlatformLoginCompatibility.requiresLogin`。
- 旧插件即使没有声明登录字段，也可以进入账号管理和登录流程。

修改 `PlatformLoginRegistry`：

- 使用兼容层返回的 `loginFlow` 和 `auth`。
- 登录入口列表可包含 Twitch / Kick / SOOP 旧 manifest。

修复 `macOS/AngelLiveMacOS/Views/PlatformDetailView.swift`：

- 平台详情页登录弹窗改为传 `viewModel.platform.pluginId`。
- 避免 `soop` 平台被错误传成 `8` 后查不到登录入口。

### 2. Cookie 收集与 Web 登录修复

新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`：

- 统一 iOS / macOS 的 Cookie 过滤、去重、签名和 UID 提取逻辑。
- 支持同站兄弟域匹配，例如 `.twitch.tv` / `www.twitch.tv`、`kick.com` / `www.kick.com`。
- Cookie header 去重时优先非空、当前 session、域名和 path 更具体的 Cookie，再比较长有效期。

修改 iOS 登录面板 `PlatformLoginWebSheet.swift`：

- 使用 `PlatformCookieCollector.filteredCookies` 收集相关域名 Cookie。
- 使用 `PlatformCookieCollector.cookieHeader` 生成最终 Cookie 字符串。
- 使用 `PlatformCookieCollector.containsAuthenticatedCookie` 判断是否已登录。
- 重新登录 / 退出登录时清理相关域名的 Cookie 和 WebKit 站点数据。
- 登录 WebView 默认使用移动 Safari 风格 UA，不再让旧 Twitch/Kick/SOOP 兜底流强制注入桌面 Chromium UA，避免 Twitch 把 WKWebView 判定成“不支持的浏览器”。
- 开启 `javaScriptCanOpenWindowsAutomatically`，并用 `WKUIDelegate` 接管 `target=_blank` / `window.open`，让 SOOP 的 Apple / Google 第三方登录按钮在当前 WebView 内继续跳转。

修改 macOS 登录面板 `MacPlatformLoginWebSheet.swift`：

- 同步 iOS 的统一 Cookie 收集逻辑。
- 打开登录页时立即轮询一次 Cookie，避免登录完成后等待下一轮定时器。
- “重新登录”和“退出登录”会清理相关平台网页登录缓存，避免旧账号 Cookie 干扰。
- Cookie 保存返回过期、无效或网络错误时显式把 `isLoggedIn` 置为 `false`，避免 UI 留在“账号信息”页。
- 登录 WebView 默认使用桌面 Safari 风格 UA，并同步处理第三方登录新窗口，保持 iOS / macOS 登录行为一致。

### 3. JSRuntime Cookie 注入修复

修改 `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift`：

- 修复 `cookieInject` 写入 body 后又被 `envelope.body` 覆盖的问题。
- 现在 body 注入结果会保留到最终请求。
- 影响场景：插件需要把 Cookie 中的字段注入请求 body 时，之前会丢失。

### 4. SOOP 直播间预览图修复

新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift`：

- 统一标准化直播间封面和头像 URL。
- 支持：
  - 去掉 JSON 转义中的 `\/`。
  - `//host/path` 补 `https:`。
  - `host/path` 补 `https://`。
  - SOOP 旧图床域 `liveimg.sooplive.co.kr` 统一到 `liveimg.sooplive.com`。
  - SOOP 图床 `http` 自动升级为 `https`。
- 当 SOOP 房间 `roomCover` 为空且 `roomId` 是数字时，兜底生成：
  - `https://liveimg.sooplive.com/m/{roomId}?320`
- 命中 SOOP 兜底时输出 `[ImageResolver][SOOP] fallback=...` 调试日志，便于真机回归判断是否命中。

修改 `LiveParseJSPlatformManager.PluginRoomDTO.toLiveModel`：

- 插件返回的 `roomCover` 和 `userHeadImg` 在进入 `LiveModel` 前先做标准化。

新增 `LiveModel` 展示扩展：

- `displayRoomCover`
- `displayUserHeadImg`

所有 UI 图片加载改用展示扩展，避免旧缓存或未标准化 URL 继续导致图片失败。

iOS SOOP 19x 实时封面补充：

- `PlatformDetailViewModel` 首次进入 SOOP 分类时预取前三页房间列表，避免 19x 房间只在滚动后才进入候选池。
- SOOP `liveimg.sooplive.com/m/{roomId}` URL 统一稳定为 `?320`，不再给所有房间追加 `_al_preview` 时间戳。
- 非 19x 房间只走普通 Kingfisher 缓存，不做实时截图、不做强制刷新。
- 19x 判定通过封面 CDN 的 `HEAD/GET` 内容长度识别灰色年龄占位图；只有命中占位图的房间才会解析播放地址并截取首帧。
- 生成的实时封面只写入 Kingfisher 内存缓存，key 为稳定的 `https://liveimg.sooplive.com/m/{roomId}?320`，不改写收藏和 CloudKit 持久化字段。
- ViewModel 记录已检测和正在处理的 `roomId`，下拉刷新、点击刷新或重复进入同一列表不会对已处理房间二次拉流截图。
- `RoomListViewController.willDisplay` 在滚动时把后续窗口交给 ViewModel，继续预加载新出现的 19x 房间。
- 真机日志已确认 19x 写入稳定 key，例如 `https://liveimg.sooplive.com/m/294067533?320`、`https://liveimg.sooplive.com/m/294050349?320`。

iOS SOOP 19x 播放控制补充：

- `UnifiedPlayerControlOverlay` 增加全屏透明 tap catcher，控制层隐藏时点击显示，显示时点击空白处隐藏。
- `PlayerContainerView` 移除 VLC drawable 上的 SwiftUI `onTapGesture`，避免 VLCKit drawable 与 SwiftUI 同时争抢 19x 流点击事件。
- `VLCVideoPlayerView` 在同一 media fingerprint 下不再从 `.paused` 强行恢复播放，只处理 `.stopped` / `.error` 恢复；销毁和 stop 时把 VLCKit stop/media 释放放到后台队列，减少主线程卡顿和闪退风险。

### 5. CHZZK 默认清晰度修复

修改 `Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift`：

- 新增 `preferredInitialSelection(in:)`。
- 默认播放不再盲目使用插件返回的第一个清晰度。
- 清晰度评分规则：
  - `audio` / `音频` 最低。
  - `auto` / `自适应` 低于明确分辨率。
  - `source` / `best` / `原画` 最高。
  - `1080p`、`720p` 等按解析出的高度排序。
  - 没有高度时回退 `qn`。
- 只在可直接播放或声明 `refreshOnSelect` 的清晰度中比较。
- 避免空 URL 的“原画 / Best”占位项抢占默认播放。
- 音频轨不会参与初始默认清晰度竞争；如果没有任何视频候选，仍保持旧逻辑的首项兜底。

修改 iOS / tvOS / macOS 的 `RoomInfoViewModel`：

- 初次拿到 `playArgs` 后使用 `preferredInitialSelection`。
- 手动切换清晰度仍保留原有路径。
- tvOS 展示当前清晰度时改用 `qualityDisplayTitle(in:selection:)`，同名不同流类型时和 iOS / macOS 一样追加 HLS / FLV 区分。

### 6. VLC fallback 构建兼容

当前默认 KSPlayer 依赖链会解析 `https://github.com/TracyPlayer/FFmpegKit`，该远端在本次验证时不可用。为了能在 Xcode 26.5 上完成本地编译验证，使用仓库已有的 `USE_VLC=1` fallback 路径。

补齐 fallback 与真实 KSPlayer 的最小接口差异：

- `Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift`
  - `KSOptions.playerTypes`
  - `KSOptions.videoFilters`
  - `KSOptions.audioFilters`
  - `KSPlayerLayerBase.reset()`
- `Shared/AngelLiveDependencies/Sources/PlayerOptions.swift`
  - `init()` 显式标记 `override`，兼容 fallback 下 `KSOptions` 的公开初始化器。
- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift`
  - 增加 `isLocked` 状态，和真实播放器模型对齐。

### 7. 真机签名兼容与订阅密钥修复

新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift`：

- 在访问命名 CloudKit 容器前统一判断签名能力。
- iOS / tvOS Debug 或 AdHoc 包通过 `embedded.mobileprovision` 读取 `com.apple.developer.icloud-container-identifiers`。
- 如果当前签名没有 `iCloud.icloud.dev.igod.simplelive`，直接跳过对应 CloudKit 操作并输出日志。
- App Store 包通常没有 `embedded.mobileprovision`，该路径仍信任正式签名 entitlement。

接入该 guard 的 CloudKit 入口：

- `FavoriteService`
- `StreamBookmarkService`
- `PluginSourceSyncService`
- `PlatformCredentialSyncService`

修复效果：

- 个人开发团队不支持 iCloud / Push 的本地真机包可以正常启动。
- 缺少 iCloud entitlement 时不再在 `CKContainer(identifier:)` 处触发 `EXC_BREAKPOINT / SIGTRAP`。
- 本地收藏、插件安装、Cookie 登录仍可继续使用；仅跳过 iCloud 同步。

修改 `PluginSourceKeyService`：

- 补齐远程 `keys.json` 地址：
  - `https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json`
  - `https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json`
- 增加官方密钥 `444222000` 的内置兜底映射。
- 远程 keys 拉取失败时，`444222000` 仍会解析到官方插件索引，不会误当成普通视频地址。

## 涉及文件

### 新增文件

- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift`
- `docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md`

### Shared / Core 修改

- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginManifest.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginRegistry.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/FavoriteService.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCredentialSyncService.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceKeyService.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceSyncService.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/StreamBookmarkService.swift`
- `Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift`

### Shared / Dependencies 修改

- `Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift`
- `Shared/AngelLiveDependencies/Sources/PlayerOptions.swift`

### iOS 修改

- `iOS/AngelLive/AngelLive/FullUI/Components/LiveRoomCard.swift`
- `iOS/AngelLive/AngelLive/Common/PlayerCore/VLCVideoPlayerView.swift`
- `iOS/AngelLive/AngelLive/FullUI/Managers/NowPlayingManager.swift`
- `iOS/AngelLive/AngelLive/FullUI/ViewModels/PlatformDetailViewModel.swift`
- `iOS/AngelLive/AngelLive/FullUI/ViewModels/RoomInfoViewModel.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/DetailPlayerView.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerContainerView.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/Player/UnifiedPlayerControlOverlay.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/VerticalLiveControllerView.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoSheet.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoView.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/Setting/PlatformLoginWebSheet.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/UIKit/ViewControllers/RoomListViewController.swift`

### tvOS 修改

- `TV/AngelLiveTVOS/Source/DetailPlayer/DetailPlayerView.swift`
- `TV/AngelLiveTVOS/Source/DetailPlayer/PlayerControlCardView.swift`
- `TV/AngelLiveTVOS/Source/DetailPlayer/RoomInfoViewModel.swift`
- `TV/AngelLiveTVOS/Source/List/LiveCardView.swift`
- `TV/TopShelfExtension/ContentProvider.swift`

### macOS 修改

- `macOS/AngelLiveMacOS/ViewModels/RoomInfoViewModel.swift`
- `macOS/AngelLiveMacOS/Views/MacPlatformLoginWebSheet.swift`
- `macOS/AngelLiveMacOS/Views/PlatformDetailView.swift`
- `macOS/AngelLiveMacOS/Views/PlayerControlView.swift`

## 新增测试覆盖

修改 `Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift`：

- `PlatformLoginCompatibilityTests`
  - 旧 Twitch / Kick / SOOP manifest 能获得宿主登录兜底。
  - manifest 自带 `loginFlow` 时优先使用 manifest，不被兜底覆盖。
- `PluginSourceKeyTests`
  - 官方短密钥 `444222000` 不依赖远程 keys 索引也能解析到官方插件索引。
- `PlatformCookieCollectorTests`
  - 兄弟域 Cookie 能正确过滤。
  - 登录信号 Cookie 能被识别。
  - Cookie header 能正确生成。
  - 同名 Cookie 去重时 session Cookie 优先于旧 persistent Cookie。
- `LiveImageURLResolverTests`
  - SOOP 空封面生成预览 CDN URL。
  - SOOP 旧图床域名 canonicalize。
  - 非 SOOP 空封面保持为空。
- `PlaybackInitialSelectionTests`
  - CHZZK 类 Auto / 720p / 1080p 列表默认选 1080p。
  - 空 URL 的“原画”占位项不会被默认选中。
  - 有视频候选时跳过 audio-only 音频轨。
  - `refreshOnSelect` 的高画质项即使 URL 为空，仍允许作为初始候选。
- `PlatformLoginCompatibilityTests`
  - manifest 显式声明 `auth.required=false` 时优先于宿主 fallback。

## 兼容性说明

- 兼容层是 data-only，后续插件 manifest 正式声明 `loginFlow` 后，会自动优先使用 manifest 字段。
- SOOP 预览图兜底只在 `liveType` 为 `8` 或 `soop`，且 `roomId` 为纯数字时启用。
- SOOP 19x 实时截图只在 iOS 列表层启用；非 19x 房间不会进入播放地址解析或截图流程。
- SOOP 19x 截图只作为 Kingfisher 内存缓存存在，App 重启后会重新按当前直播状态检测，不污染收藏、历史或 iCloud 数据。
- UI 层保留原 `LiveModel.roomCover` / `userHeadImg` 字段，只新增展示用扩展，避免影响持久化模型结构。
- 清晰度选择只改变初始默认项，用户手动切换清晰度流程未重写。

## 验证结果

已执行：

```bash
git diff --check
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Shared/AngelLiveCore
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer USE_VLC=1 xcodebuild build -workspace AngelLive.xcworkspace -scheme AngelLive -configuration Debug -destination 'platform=iOS,id=00008130-000204881E6A001C' -allowProvisioningUpdates -skipPackagePluginValidation
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device install app --device 6F726895-0F44-53B8-9291-C68C6C5B11A2 /Users/bing/Library/Developer/Xcode/DerivedData/AngelLive-gcijnxzpyclukqgalnuqneqbaqcp/Build/Products/Debug-iphoneos/AngelLive.app
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device process launch --device 6F726895-0F44-53B8-9291-C68C6C5B11A2 --terminate-existing --console com.anlonely.AngelLiveTest
```

结果：

- `git diff --check` 通过。
- Xcode 工具链直接运行 Core 测试通过：`30 tests passed`。
- iOS 26.1 真机 Debug 构建通过：`** BUILD SUCCEEDED **`。
- iOS 26.1 真机安装和 console 启动通过。

真机状态：

- Xcode 26.5 能识别已连接 iPhone 15 Pro，设备系统为 iOS 26.1，开发者模式已启用。
- 使用本地测试 bundle id `com.anlonely.AngelLiveTest` 和个人开发团队完成真机安装。
- 个人开发团队不支持 iCloud / Push，本地 Debug 包改用空 entitlement 验证；修复前启动在 `CKContainer(identifier:)` 崩溃，修复后可稳定进入 App。
- iPhone Mirroring 实时验证：欢迎页、收藏页、配置页、设置页可打开。
- 输入订阅密钥 `444222000` 后弹出订阅内容列表，并成功安装 14 个官方插件。
- 设备容器确认已安装插件包含 `chzzk`、`kick`、`soop`、`twitch`，订阅源持久化为 `https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/plugins.json`。
- SOOP 首次进入分类时真机日志确认只拉取第 1、2、3 页房间列表，然后开始处理 19x 候选。
- SOOP 19x 实时封面真机日志确认写入稳定 Kingfisher key：`https://liveimg.sooplive.com/m/{roomId}?320`，未再出现 `_al_preview` 时间戳缓存 key。
- SOOP 播放控制真机复测：点击画面可弹出控制层，不再出现左键点击导致的持续闪烁和卡死。

## 审查建议

- 重点审查 `RoomPlaybackResolver.preferredInitialSelection` 是否符合 CHZZK 插件实际返回的 `playArgs` 结构。
- 重点审查 `PlatformLoginCompatibility` 中 Twitch / Kick / SOOP 的 Cookie 名称和域名是否覆盖当前线上行为。
- 重点审查 SOOP 兜底预览地址 `https://liveimg.sooplive.com/m/{roomId}` 在目标地区和网络环境下是否可访问。
- 重点审查 iOS SOOP 19x 实时截图策略是否接受：只在内存缓存中替换稳定 `?320` key，App 重启后重新检测。
- 真机连接后建议验证 iOS 26.1 设备上的 WebKit 登录保存、播放器默认清晰度、SOOP 列表预览图和 SOOP 19x 播放控制四条主链路。
