### PR TITLE
[codex] 修复平台登录、清晰度、SOOP 19x 和 Twitch 分类

### DIFF
--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift
@@ -653,8 +653,12 @@ private struct PluginRoomDTO: Decodable {
         LiveModel(
             userName: userName,
             roomTitle: roomTitle,
-            roomCover: roomCover,
-            userHeadImg: userHeadImg,
+            roomCover: LiveImageURLResolver.roomCoverURLString(
+                rawValue: roomCover,
+                liveType: liveType,
+                roomId: roomId
+            ),
+            userHeadImg: LiveImageURLResolver.avatarURLString(rawValue: userHeadImg),
             liveType: liveType,
             liveState: liveState,
             userId: userId,

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift
@@ -395,6 +395,8 @@ private extension JSRuntime {
                 }
             }
 
+            var requestBody = envelope.body
+
             // 通用 cookieInject：从 cookie 取值注入到 header、query 或 body
             if !envelope.cookieInject.isEmpty {
                 var mutableURL = envelope.urlString
@@ -420,7 +422,7 @@ private extension JSRuntime {
                     case .body:
                         guard let bodyPath = rule.bodyPath else { continue }
                         if bodyJSON == nil {
-                            if let existing = request.httpBody,
+                            if let existing = requestBody,
                                let parsed = try? JSONSerialization.jsonObject(with: existing) as? [String: Any] {
                                 bodyJSON = parsed
                             } else {
@@ -436,7 +438,9 @@ private extension JSRuntime {
                     request.url = newURL
                 }
                 if let bodyJSON {
-                    request.httpBody = try? JSONSerialization.data(withJSONObject: bodyJSON)
+                    // Keep cookieInject body changes as the final request body.
+                    // Previously this was overwritten by envelope.body below.
+                    requestBody = try? JSONSerialization.data(withJSONObject: bodyJSON)
                 }
             }
 
@@ -444,7 +448,7 @@ private extension JSRuntime {
                 request.setValue(value, forHTTPHeaderField: key)
             }
 
-            request.httpBody = envelope.body
+            request.httpBody = requestBody
 
             // 开发者控制台：记录请求开始时间
             let httpStartTime = CFAbsoluteTimeGetCurrent()

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParseLoadedPlugin.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParseLoadedPlugin.swift
@@ -49,6 +49,7 @@ public actor LiveParseLoadedPlugin {
         if actual != JSRuntime.supportedAPIVersion {
             throw LiveParsePluginError.incompatibleAPIVersion(expected: JSRuntime.supportedAPIVersion, actual: actual)
         }
+        try await LiveParsePluginCompatibilityPatch.apply(to: runtime, manifest: manifest)
         isLoaded = true
     }
 }

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+enum LiveParsePluginCompatibilityPatch {
+    static func apply(to runtime: JSRuntime, manifest: LiveParsePluginManifest) async throws {
+        guard let script = script(for: manifest) else {
+            return
+        }
+        try await runtime.evaluate(script: script)
+    }
+
+    static func script(for manifest: LiveParsePluginManifest) -> String? {
+        switch (manifest.pluginId, manifest.version) {
+        case ("twitch", "1.0.31"):
+            return twitch1031GQLListPatch
+        default:
+            return nil
+        }
+    }
+
+    // Twitch 1.0.31 declares a website-GQL rewrite, but its exported category
+    // and room-list methods still call the Helix token-server path. That server
+    // can return payloads without clientId/accessToken, which blocks the whole
+    // platform page before users reach playback. Reuse the GQL helpers already
+    // bundled inside the plugin and keep the patch exact-version scoped so a
+    // rebuilt upstream plugin is not overridden.
+    private static let twitch1031GQLListPatch = #"""
+    (function () {
+      var plugin = globalThis.LiveParsePlugin;
+      if (!plugin || plugin.__angelLiveTwitchGQLListPatch === true) return;
+
+      var originalGetCategories =
+        typeof plugin.getCategories === "function" ? plugin.getCategories.bind(plugin) : null;
+      var originalGetRooms =
+        typeof plugin.getRooms === "function" ? plugin.getRooms.bind(plugin) : null;
+
+      function stringValue(value) {
+        return value === undefined || value === null ? "" : String(value);
+      }
+
+      function intValue(value, fallback) {
+        var parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : fallback;
+      }
+
+      function runtimePayload(payload) {
+        return payload && typeof payload === "object" ? Object.assign({}, payload) : {};
+      }
+
+      function roomPageSize(value) {
+        if (typeof _tw_roomPageSize === "function") return _tw_roomPageSize(value);
+        return Math.max(1, Math.min(100, intValue(value, 20)));
+      }
+
+      function dedupeRooms(rooms) {
+        if (typeof _tw_dedupeRooms === "function") return _tw_dedupeRooms(rooms);
+        var seen = {};
+        return (Array.isArray(rooms) ? rooms : []).filter(function (room) {
+          var key = stringValue(room && (room.roomId || room.userId || room.userName));
+          if (!key || seen[key]) return false;
+          seen[key] = true;
+          return true;
+        });
+      }
+
+      function buildCategoryTree(categories) {
+        var safeCategories = Array.isArray(categories) ? categories : [];
+        return [
+          {
+            id: "root",
+            title: "Twitch",
+            icon: stringValue(safeCategories[0] && safeCategories[0].icon),
+            biz: "",
+            subList: [
+              {
+                id: "all",
+                parentId: "root",
+                title: "全部直播",
+                icon: "",
+                biz: ""
+              }
+            ].concat(
+              safeCategories.map(function (item) {
+                return {
+                  id: stringValue(item && item.id),
+                  parentId: "root",
+                  title: stringValue(item && item.title),
+                  icon: stringValue(item && item.icon),
+                  biz: stringValue(item && item.biz)
+                };
+              })
+            )
+          }
+        ];
+      }
+
+      plugin.getCategories = async function (payload) {
+        var runtime = runtimePayload(payload);
+        var cached = null;
+
+        if (typeof _tw_loadCategoryCache === "function") {
+          try {
+            cached = await _tw_loadCategoryCache(120);
+          } catch (_) {
+            cached = null;
+          }
+        }
+
+        if (cached && cached.fresh && Array.isArray(cached.categories) && cached.categories.length > 0) {
+          return buildCategoryTree(cached.categories);
+        }
+
+        if (typeof _tw_fetchTopGames !== "function") {
+          if (originalGetCategories) return await originalGetCategories(payload);
+          return buildCategoryTree([]);
+        }
+
+        try {
+          var categories = await _tw_fetchTopGames(100, runtime);
+          if (typeof _tw_saveCategoryCache === "function") {
+            try {
+              await _tw_saveCategoryCache(categories);
+            } catch (_) {}
+          }
+          return buildCategoryTree(categories);
+        } catch (error) {
+          if (cached && Array.isArray(cached.categories) && cached.categories.length > 0) {
+            return buildCategoryTree(cached.categories);
+          }
+          throw error;
+        }
+      };
+
+      plugin.getRooms = async function (payload) {
+        var runtime = runtimePayload(payload);
+        var categoryId = stringValue(runtime.id) === "root" ? "all" : stringValue(runtime.id) || "all";
+        var page = Math.max(1, intValue(runtime.page, 1));
+        var pageSize = roomPageSize(runtime.pageSize);
+        var pageData = null;
+
+        if (categoryId === "all") {
+          if (typeof _tw_fetchAllStreamsPage !== "function") {
+            return originalGetRooms ? await originalGetRooms(payload) : [];
+          }
+          pageData = await _tw_fetchAllStreamsPage(page, pageSize, runtime);
+        } else {
+          if (typeof _tw_fetchCategoryStreamsPage !== "function") {
+            return originalGetRooms ? await originalGetRooms(payload) : [];
+          }
+          pageData = await _tw_fetchCategoryStreamsPage(categoryId, page, pageSize, runtime);
+        }
+
+        return dedupeRooms(pageData && pageData.items);
+      };
+
+      Object.defineProperty(plugin, "__angelLiveTwitchGQLListPatch", {
+        value: true,
+        enumerable: false
+      });
+    })();
+    """#
+}

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift
@@ -50,6 +50,16 @@ enum LiveParsePluginCompatibilityPatch {
         return stringValue(value).trim().toLowerCase();
       }
 
+      function categorySlug(value) {
+        var normalized = normalizedKey(value);
+        if (!normalized || normalized === "all" || normalized === "root" || /^\d+$/.test(normalized)) {
+          return "";
+        }
+        var match = normalized.match(/(?:^|\/)directory\/category\/([^/?#]+)/);
+        if (match && match[1]) return decodeURIComponent(match[1]);
+        return normalized.indexOf("/") >= 0 ? "" : normalized;
+      }
+
       function roomPageSize(value) {
         if (typeof _tw_roomPageSize === "function") return _tw_roomPageSize(value);
         return Math.max(1, Math.min(100, intValue(value, 20)));
@@ -72,11 +82,18 @@ enum LiveParsePluginCompatibilityPatch {
 
       function categorySelection(runtime) {
         var category = categoryPayload(runtime);
-        var rawId = stringValue(runtime.id || category.id).trim();
-        var slug = normalizedKey(runtime.slug || runtime.biz || category.biz);
+        var directId = stringValue(runtime.id).trim();
+        var categoryId = stringValue(category.id).trim();
+        var rawId =
+          directId && directId !== "all" && directId !== "root" ? directId : categoryId || directId;
+        var slug =
+          categorySlug(runtime.slug) ||
+          categorySlug(runtime.biz) ||
+          categorySlug(category.biz) ||
+          categorySlug(rawId);
 
         if (!slug && rawId && rawId !== "all" && rawId !== "root" && !/^\d+$/.test(rawId)) {
-          slug = normalizedKey(rawId);
+          slug = categorySlug(rawId);
         }
 
         if ((rawId === "all" || rawId === "root" || !rawId) && !slug) {

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift
@@ -46,6 +46,10 @@ enum LiveParsePluginCompatibilityPatch {
         return payload && typeof payload === "object" ? Object.assign({}, payload) : {};
       }
 
+      function normalizedKey(value) {
+        return stringValue(value).trim().toLowerCase();
+      }
+
       function roomPageSize(value) {
         if (typeof _tw_roomPageSize === "function") return _tw_roomPageSize(value);
         return Math.max(1, Math.min(100, intValue(value, 20)));
@@ -60,6 +64,82 @@ enum LiveParsePluginCompatibilityPatch {
           seen[key] = true;
           return true;
         });
+      }
+
+      function categoryPayload(runtime) {
+        return runtime && runtime.category && typeof runtime.category === "object" ? runtime.category : {};
+      }
+
+      function categorySelection(runtime) {
+        var category = categoryPayload(runtime);
+        var rawId = stringValue(runtime.id || category.id).trim();
+        var slug = normalizedKey(runtime.slug || runtime.biz || category.biz);
+
+        if (!slug && rawId && rawId !== "all" && rawId !== "root" && !/^\d+$/.test(rawId)) {
+          slug = normalizedKey(rawId);
+        }
+
+        if ((rawId === "all" || rawId === "root" || !rawId) && !slug) {
+          return { id: "all", slug: "", rawId: rawId };
+        }
+
+        return {
+          id: /^\d+$/.test(rawId) ? rawId : "",
+          slug: slug,
+          rawId: rawId
+        };
+      }
+
+      function matchingCategory(categories, selection) {
+        var list = Array.isArray(categories) ? categories : [];
+        for (var i = 0; i < list.length; i += 1) {
+          var item = list[i] || {};
+          if (selection.id && stringValue(item.id) === selection.id) return item;
+          if (selection.slug && normalizedKey(item.biz) === selection.slug) return item;
+        }
+        return null;
+      }
+
+      async function resolveCategorySelection(runtime) {
+        var selection = categorySelection(runtime);
+        if (selection.id === "all" || selection.id) return selection;
+        if (!selection.slug) return selection;
+
+        var cachedCategories = [];
+        if (typeof _tw_loadCategoryCache === "function") {
+          try {
+            var cached = await _tw_loadCategoryCache(120);
+            cachedCategories = Array.isArray(cached && cached.categories) ? cached.categories : [];
+          } catch (_) {
+            cachedCategories = [];
+          }
+        }
+
+        var match = matchingCategory(cachedCategories, selection);
+        if (!match && typeof _tw_fetchTopGames === "function") {
+          var freshCategories = await _tw_fetchTopGames(100, runtime);
+          match = matchingCategory(freshCategories, selection);
+          if (typeof _tw_saveCategoryCache === "function" && Array.isArray(freshCategories)) {
+            try {
+              await _tw_saveCategoryCache(freshCategories);
+            } catch (_) {}
+          }
+        }
+
+        if (match && stringValue(match.id)) {
+          selection.id = stringValue(match.id);
+        }
+        return selection;
+      }
+
+      function filterRoomsForCategory(rooms, selection) {
+        var list = dedupeRooms(rooms);
+        if (!selection || selection.id === "all" || !selection.id) return list;
+
+        var filtered = list.filter(function (room) {
+          return stringValue(room && room.biz) === selection.id;
+        });
+        return filtered.length > 0 || list.length === 0 ? filtered : list;
       }
 
       function buildCategoryTree(categories) {
@@ -132,7 +212,8 @@ enum LiveParsePluginCompatibilityPatch {
 
       plugin.getRooms = async function (payload) {
         var runtime = runtimePayload(payload);
-        var categoryId = stringValue(runtime.id) === "root" ? "all" : stringValue(runtime.id) || "all";
+        var selection = await resolveCategorySelection(runtime);
+        var categoryId = selection.id || selection.rawId || "all";
         var page = Math.max(1, intValue(runtime.page, 1));
         var pageSize = roomPageSize(runtime.pageSize);
         var pageData = null;
@@ -149,7 +230,7 @@ enum LiveParsePluginCompatibilityPatch {
           pageData = await _tw_fetchCategoryStreamsPage(categoryId, page, pageSize, runtime);
         }
 
-        return dedupeRooms(pageData && pageData.items);
+        return filterRoomsForCategory(pageData && pageData.items, selection);
       };
 
       Object.defineProperty(plugin, "__angelLiveTwitchGQLListPatch", {

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginManifest.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginManifest.swift
@@ -245,6 +245,6 @@ extension LiveParsePluginManifest {
 
     /// 该插件是否需要用户登录平台账号(用于安装前的凭证泄露风险确认)。
     public var requiresLogin: Bool {
-        (auth?.required == true) || (loginFlow != nil)
+        PlatformLoginCompatibility.requiresLogin(self)
     }
 }

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift
@@ -132,6 +132,32 @@ public enum RoomPlaybackResolver {
         return nil
     }
 
+    /// Selects the best initial playable item without trusting plugin order.
+    /// This protects platforms like CHZZK when a playlist contains `Auto` or
+    /// lower variants before the concrete 1080p/720p entries.
+    public static func preferredInitialSelection(in playArgs: [LiveQualityModel]?) -> RoomPlaybackSelection? {
+        guard let fallback = firstSelection(in: playArgs), let playArgs else { return nil }
+
+        var bestSelection: RoomPlaybackSelection?
+        var bestScore = Int.min
+
+        for (cdnIndex, cdn) in playArgs.enumerated() {
+            for (qualityIndex, quality) in cdn.qualitys.enumerated() {
+                guard isInitialPlaybackCandidate(quality) else { continue }
+                let score = initialQualityScore(quality)
+                guard score > bestScore else { continue }
+                bestScore = score
+                bestSelection = RoomPlaybackSelection(
+                    cdnIndex: cdnIndex,
+                    qualityIndex: qualityIndex,
+                    quality: quality
+                )
+            }
+        }
+
+        return bestSelection ?? fallback
+    }
+
     public static func firstSelection(
         in playArgs: [LiveQualityModel]?,
         where predicate: (LiveQualityDetail) -> Bool
@@ -421,5 +447,47 @@ public enum RoomPlaybackResolver {
         }
 
         return false
+    }
+
+    private static func initialQualityScore(_ quality: LiveQualityDetail) -> Int {
+        let title = quality.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if title.contains("audio") || title.contains("音频") {
+            return -1
+        }
+        if title.contains("auto") || title.contains("自适应") {
+            return 0
+        }
+        if title.contains("source") || title.contains("best") || title.contains("原画") {
+            return 10_000_000
+        }
+
+        let titleHeight = parsedHeight(from: title)
+        let qnScore = max(quality.qn, 0)
+        if titleHeight > 0 {
+            return titleHeight * 1_000 + min(qnScore, 999)
+        }
+        return qnScore
+    }
+
+    private static func isInitialPlaybackCandidate(_ quality: LiveQualityDetail) -> Bool {
+        let title = quality.title.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if title.contains("audio") || title.contains("音频") {
+            return false
+        }
+        return playableURL(for: quality) != nil || requiresRefreshOnSelect(quality)
+    }
+
+    private static func parsedHeight(from title: String) -> Int {
+        let pattern = #"(\d{3,4})\s*p"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else {
+            return 0
+        }
+        let range = NSRange(title.startIndex..<title.endIndex, in: title)
+        guard let match = regex.firstMatch(in: title, options: [], range: range),
+              match.numberOfRanges >= 2,
+              let heightRange = Range(match.range(at: 1), in: title) else {
+            return 0
+        }
+        return Int(title[heightRange]) ?? 0
     }
 }

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift
@@ -1,0 +1,84 @@
+//
+//  CloudKitContainerAccess.swift
+//  AngelLiveCore
+//
+//  Centralized guard before touching CKContainer. Personal development
+//  profiles can install the app without iCloud entitlement; initializing a
+//  named CKContainer in that state traps before Swift can catch an error.
+//
+
+import CloudKit
+import Foundation
+
+enum CloudKitContainerAccess {
+    private static let iCloudContainerEntitlementKey = "com.apple.developer.icloud-container-identifiers"
+
+    static func privateDatabase(
+        containerIdentifier: String,
+        purpose: String,
+        category: LogCategory = .cloudKit
+    ) -> CKDatabase? {
+        guard hasICloudContainer(containerIdentifier) else {
+            Logger.info("当前签名未包含 iCloud entitlement，跳过\(purpose)", category: category)
+            return nil
+        }
+        return CKContainer(identifier: containerIdentifier).privateCloudDatabase
+    }
+
+    static func container(
+        identifier: String,
+        purpose: String,
+        category: LogCategory = .cloudKit
+    ) -> CKContainer? {
+        guard hasICloudContainer(identifier) else {
+            Logger.info("当前签名未包含 iCloud entitlement，跳过\(purpose)", category: category)
+            return nil
+        }
+        return CKContainer(identifier: identifier)
+    }
+
+    static func hasICloudContainer(_ identifier: String) -> Bool {
+        guard !identifier.isEmpty else { return false }
+
+        #if os(iOS) || os(tvOS)
+        guard let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision") else {
+            // App Store packages normally omit embedded.mobileprovision; trust the signed entitlement there.
+            return true
+        }
+        guard let entitlements = embeddedProvisioningEntitlements(at: url) else {
+            return false
+        }
+
+        if let containers = entitlements[iCloudContainerEntitlementKey] as? [String] {
+            return containers.contains(identifier)
+        }
+        if let container = entitlements[iCloudContainerEntitlementKey] as? String {
+            return container == identifier
+        }
+        return false
+        #else
+        return true
+        #endif
+    }
+
+    #if os(iOS) || os(tvOS)
+    /// Debug/AdHoc builds include a CMS mobileprovision file with an embedded plist.
+    private static func embeddedProvisioningEntitlements(at url: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: url),
+              let start = data.range(of: Data("<?xml".utf8)),
+              let end = data.range(of: Data("</plist>".utf8), in: start.lowerBound..<data.endIndex) else {
+            return nil
+        }
+
+        let plistData = Data(data[start.lowerBound..<end.upperBound])
+        guard let plist = try? PropertyListSerialization.propertyList(
+            from: plistData,
+            options: [],
+            format: nil
+        ) as? [String: Any] else {
+            return nil
+        }
+        return plist["Entitlements"] as? [String: Any]
+    }
+    #endif
+}

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/FavoriteService.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/FavoriteService.swift
@@ -21,8 +21,17 @@ private enum CloudFavoriteFields {
 }
 
 public final class FavoriteService: NSObject {
+    private static func cloudDatabase(purpose: String) -> CKDatabase? {
+        CloudKitContainerAccess.privateDatabase(
+            containerIdentifier: CloudFavoriteFields.containerIdentifier,
+            purpose: purpose,
+            category: .favorite
+        )
+    }
     
     public static func saveRecord(liveModel: LiveModel) async throws {
+        guard let database = cloudDatabase(purpose: "收藏 CloudKit 保存") else { return }
+
         let rec = CKRecord(recordType: "favorite_streamers")
         rec.setValue(liveModel.roomId, forKey: CloudFavoriteFields.roomId)
         rec.setValue(liveModel.userId, forKey: CloudFavoriteFields.userId)
@@ -32,12 +41,12 @@ public final class FavoriteService: NSObject {
         rec.setValue(liveModel.userHeadImg, forKey: CloudFavoriteFields.userHeadImage)
         rec.setValue(liveModel.liveType.rawValue, forKey: CloudFavoriteFields.liveType)
         rec.setValue(liveModel.liveState ?? "", forKey: CloudFavoriteFields.liveState)
-        try await CKContainer(identifier: CloudFavoriteFields.containerIdentifier).privateCloudDatabase.save(rec)
+        try await database.save(rec)
     }
     
     public static func searchRecord(roomId: String) async throws -> [LiveModel] {
-        let container = CKContainer(identifier: CloudFavoriteFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "收藏 CloudKit 查询") else { return [] }
+
         let predicate = NSPredicate(format: " \(CloudFavoriteFields.roomId) = '\(roomId)' ")
         let query = CKQuery(recordType: "favorite_streamers", predicate: predicate)
         // 使用新的 API
@@ -61,8 +70,8 @@ public final class FavoriteService: NSObject {
     }
     
     public static func searchRecord() async throws -> [LiveModel] {
-        let container = CKContainer(identifier: CloudFavoriteFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "收藏 CloudKit 列表查询") else { return [] }
+
         let query = CKQuery(recordType: "favorite_streamers", predicate: NSPredicate(value: true))
         // 使用新的 API
         let recordArray = try await database.records(matching: query, resultsLimit: 99999)
@@ -99,8 +108,8 @@ public final class FavoriteService: NSObject {
     }
     
     public static func deleteRecord(liveModel: LiveModel) async throws {
-        let container = CKContainer(identifier: CloudFavoriteFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "收藏 CloudKit 删除") else { return }
+
         let trimmedUserId = liveModel.userId.trimmingCharacters(in: .whitespacesAndNewlines)
         let predicate: NSPredicate
         if PlatformHostBehavior.favoriteIdentityKey(for: liveModel.liveType) == .userId, !trimmedUserId.isEmpty {
@@ -129,6 +138,9 @@ public final class FavoriteService: NSObject {
         guard !CloudFavoriteFields.containerIdentifier.isEmpty else {
             return "CloudKit 配置错误：容器标识符为空"
         }
+        guard CloudKitContainerAccess.hasICloudContainer(CloudFavoriteFields.containerIdentifier) else {
+            return "当前签名未包含 iCloud 权限，已跳过 iCloud 同步"
+        }
         
         // 2. 检查 CloudKit 可用性
         guard CKContainer.default().containerIdentifier != nil else {
@@ -141,7 +153,14 @@ public final class FavoriteService: NSObject {
             if CloudFavoriteFields.containerIdentifier == CKContainer.default().containerIdentifier {
                 container = CKContainer.default()
             } else {
-                container = CKContainer(identifier: CloudFavoriteFields.containerIdentifier)
+                guard let guardedContainer = CloudKitContainerAccess.container(
+                    identifier: CloudFavoriteFields.containerIdentifier,
+                    purpose: "CloudKit 状态检查",
+                    category: .favorite
+                ) else {
+                    return "当前签名未包含 iCloud 权限，已跳过 iCloud 同步"
+                }
+                container = guardedContainer
             }
             
             // 4. 添加超时保护

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Normalizes room image URLs before UI code hands them to Kingfisher.
+///
+/// Plugins should ideally return final absolute image URLs. This resolver keeps
+/// host-side compatibility for older plugin versions and saved records that may
+/// contain empty, scheme-relative, or legacy-domain image values.
+public enum LiveImageURLResolver {
+    public static func roomCoverURLString(
+        rawValue: String,
+        liveType: LiveType,
+        roomId: String
+    ) -> String {
+        let normalizedRaw = normalizedURLString(rawValue)
+        if !normalizedRaw.isEmpty {
+            return normalizedRaw
+        }
+
+        guard isSOOP(liveType),
+              let fallback = soopLivePreviewURLString(roomId: roomId) else {
+            return ""
+        }
+
+        // SOOP sometimes omits thumbnails on authenticated/detail paths while
+        // the CDN still exposes previews deterministically by broad_no.
+        Logger.debug("[ImageResolver][SOOP] fallback=\(fallback)", category: .general)
+        return fallback
+    }
+
+    public static func soopLivePreviewURLString(roomId: String, refreshToken: String? = nil) -> String? {
+        let trimmedRoomId = roomId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isNumericRoomId(trimmedRoomId) else { return nil }
+
+        var preview = "https://liveimg.sooplive.com/m/\(trimmedRoomId)?320"
+        if let refreshToken = refreshToken?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !refreshToken.isEmpty {
+            preview += "&_al_preview=\(refreshToken)"
+        }
+        return preview
+    }
+
+    public static func avatarURLString(rawValue: String) -> String {
+        normalizedURLString(rawValue)
+    }
+
+    public static func normalizedURLString(_ rawValue: String) -> String {
+        var value = rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\\/", with: "/")
+
+        guard !value.isEmpty else { return "" }
+
+        if value.hasPrefix("//") {
+            value = "https:" + value
+        } else if !hasScheme(value),
+                  looksLikeHostPath(value) {
+            value = "https://" + value
+        }
+
+        guard var components = URLComponents(string: value) else {
+            return value
+        }
+
+        if components.scheme?.lowercased() == "http", isSOOPImageHost(components.host) {
+            components.scheme = "https"
+        }
+
+        if components.host?.lowercased() == "liveimg.sooplive.co.kr" {
+            components.host = "liveimg.sooplive.com"
+        }
+
+        return components.string ?? value
+    }
+
+    private static func hasScheme(_ value: String) -> Bool {
+        value.range(of: #"^[A-Za-z][A-Za-z0-9+\-.]*://"#, options: .regularExpression) != nil
+    }
+
+    private static func looksLikeHostPath(_ value: String) -> Bool {
+        guard let first = value.split(separator: "/", maxSplits: 1).first else {
+            return false
+        }
+        return first.contains(".")
+    }
+
+    private static func isSOOP(_ liveType: LiveType) -> Bool {
+        let raw = liveType.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return raw == "8" || raw == "soop"
+    }
+
+    private static func isSOOPImageHost(_ host: String?) -> Bool {
+        guard let host = host?.lowercased() else { return false }
+        return host == "liveimg.sooplive.com" || host == "liveimg.sooplive.co.kr"
+    }
+
+    private static func isNumericRoomId(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && trimmed.allSatisfy(\.isNumber)
+    }
+}
+
+public extension LiveModel {
+    var displayRoomCover: String {
+        let resolvedCover = LiveImageURLResolver.roomCoverURLString(
+            rawValue: roomCover,
+            liveType: liveType,
+            roomId: roomId
+        )
+        if !resolvedCover.isEmpty {
+            return resolvedCover
+        }
+
+        let rawLiveType = liveType.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if rawLiveType == "8" || rawLiveType == "soop" {
+            // Older SOOP favorites may only have bjId/station id, not broad_no.
+            // Use the avatar as a visible fallback instead of a blank card.
+            return LiveImageURLResolver.avatarURLString(rawValue: userHeadImg)
+        }
+        return ""
+    }
+
+    var displayUserHeadImg: String {
+        LiveImageURLResolver.avatarURLString(rawValue: userHeadImg)
+    }
+}

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Shared Cookie handling for platform login web views.
+///
+/// Some third-party platforms set auth cookies on sibling domains
+/// (`www.twitch.tv` vs `.twitch.tv`, `kick.com` vs `.kick.com`). Keeping the
+/// filtering and de-duplication rules here avoids iOS/macOS/tvOS drifting apart.
+public enum PlatformCookieCollector {
+    public static func filteredCookies(
+        from cookies: [HTTPCookie],
+        loginFlow: ManifestLoginFlow
+    ) -> [HTTPCookie] {
+        let hints = domainHints(for: loginFlow)
+        guard !hints.isEmpty else { return cookies }
+        return cookies.filter { cookie in
+            hints.contains { hint in
+                domainMatches(cookie.domain, hint: hint)
+            }
+        }
+    }
+
+    public static func containsAuthenticatedCookie(
+        in cookies: [HTTPCookie],
+        loginFlow: ManifestLoginFlow
+    ) -> Bool {
+        let names = Set(cookies.map(\.name))
+        return loginFlow.authSignalCookies.contains { names.contains($0) }
+    }
+
+    public static func cookieHeader(from cookies: [HTTPCookie]) -> String {
+        var bestByName: [String: HTTPCookie] = [:]
+        for cookie in cookies {
+            guard !cookie.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                continue
+            }
+            if let existing = bestByName[cookie.name] {
+                if isPreferredCookie(cookie, over: existing) {
+                    bestByName[cookie.name] = cookie
+                }
+            } else {
+                bestByName[cookie.name] = cookie
+            }
+        }
+
+        return bestByName.values
+            .sorted(by: cookieSort)
+            .map { "\($0.name)=\($0.value)" }
+            .joined(separator: "; ")
+    }
+
+    public static func signature(from cookies: [HTTPCookie]) -> String {
+        cookies
+            .sorted(by: cookieSort)
+            .map { "\($0.name)=\($0.value)" }
+            .joined(separator: ";")
+    }
+
+    public static func extractUID(
+        from cookies: [HTTPCookie],
+        loginFlow: ManifestLoginFlow
+    ) -> String? {
+        let uidNames = loginFlow.uidCookieNames ?? ["DedeUserID", "uid", "user_id", "userId"]
+        for name in uidNames {
+            if let value = cookies.first(where: { $0.name == name })?.value,
+               !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+
+    public static func domainHints(for loginFlow: ManifestLoginFlow) -> [String] {
+        var hints = loginFlow.cookieDomains
+        if let host = URL(string: loginFlow.loginURL)?.host {
+            hints.append(host)
+        }
+        if let host = loginFlow.websiteHost {
+            hints.append(host)
+        }
+        return Array(Set(hints.map(normalizedDomain).filter { !$0.isEmpty })).sorted()
+    }
+
+    public static func domainMatches(_ cookieDomain: String, hint: String) -> Bool {
+        let domain = normalizedDomain(cookieDomain)
+        let normalizedHint = normalizedDomain(hint)
+        guard !domain.isEmpty, !normalizedHint.isEmpty else { return false }
+
+        return domain == normalizedHint
+            || domain.hasSuffix("." + normalizedHint)
+            || normalizedHint.hasSuffix("." + domain)
+    }
+
+    public static func normalizedDomain(_ domain: String) -> String {
+        domain
+            .lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: ". "))
+    }
+
+    private static func isPreferredCookie(_ candidate: HTTPCookie, over current: HTTPCookie) -> Bool {
+        // Prefer active session cookies and more specific domains/paths when
+        // duplicate names appear on sibling domains during WebKit login.
+        let candidatePriority = cookiePriorityValues(candidate)
+        let currentPriority = cookiePriorityValues(current)
+
+        for index in candidatePriority.indices {
+            if candidatePriority[index] != currentPriority[index] {
+                return candidatePriority[index] > currentPriority[index]
+            }
+        }
+        return true
+    }
+
+    private static func cookiePriorityValues(_ cookie: HTTPCookie) -> [Int] {
+        [
+            cookie.value.isEmpty ? 0 : 1,
+            cookie.isSessionOnly ? 1 : 0,
+            normalizedDomain(cookie.domain).count,
+            cookie.path.count,
+            Int(cookie.expiresDate?.timeIntervalSince1970 ?? 0)
+        ]
+    }
+
+    private static func cookieSort(_ lhs: HTTPCookie, _ rhs: HTTPCookie) -> Bool {
+        if lhs.name != rhs.name {
+            return lhs.name < rhs.name
+        }
+        if lhs.domain != rhs.domain {
+            return lhs.domain < rhs.domain
+        }
+        return lhs.path < rhs.path
+    }
+}

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCredentialSyncService.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCredentialSyncService.swift
@@ -175,8 +175,9 @@ public final class PlatformCredentialSyncService: ObservableObject {
             result[pluginId] = session
         }
 
-        let container = CKContainer(identifier: CloudCookieFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "平台登录态 CloudKit 同步") else {
+            return
+        }
 
         // 获取现有所有 cloudRecord 的 pluginId 列表
         let allPluginIds = Set(sessionsByPluginId.keys)
@@ -222,8 +223,9 @@ public final class PlatformCredentialSyncService: ObservableObject {
         isSyncing = true
         defer { isSyncing = false }
 
-        let container = CKContainer(identifier: CloudCookieFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "平台登录态 CloudKit 拉取") else {
+            return
+        }
 
         await migrateLegacyCloudRecords(database: database)
 
@@ -271,8 +273,9 @@ public final class PlatformCredentialSyncService: ObservableObject {
     }
 
     public func fetchCloudSyncPreview() async -> ICloudSyncPreview {
-        let container = CKContainer(identifier: CloudCookieFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "平台登录态 CloudKit 预览") else {
+            return ICloudSyncPreview(latestTime: nil, platformNames: [])
+        }
 
         var latestDate: Date?
         var platformNames: [String] = []
@@ -303,8 +306,9 @@ public final class PlatformCredentialSyncService: ObservableObject {
         isSyncing = true
         defer { isSyncing = false }
 
-        let container = CKContainer(identifier: CloudCookieFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = cloudDatabase(purpose: "平台登录态 CloudKit 清理") else {
+            return 0
+        }
         var recordIDsByName: [String: CKRecord.ID] = [:]
 
         let query = CKQuery(recordType: CloudCookieFields.recordType, predicate: NSPredicate(value: true))
@@ -567,8 +571,9 @@ public final class PlatformCredentialSyncService: ObservableObject {
         loggedInByPluginId[pluginId] = false
 
         if clearICloud {
-            let container = CKContainer(identifier: CloudCookieFields.containerIdentifier)
-            let database = container.privateCloudDatabase
+            guard let database = cloudDatabase(purpose: "平台登录态 CloudKit 删除") else {
+                return
+            }
             let recordName = CloudCookieFields.sessionRecordName(for: pluginId)
             let recordID = CKRecord.ID(recordName: recordName)
             do {
@@ -616,6 +621,14 @@ public final class PlatformCredentialSyncService: ObservableObject {
         let now = Date()
         lastICloudSyncTime = now
         UserDefaults.standard.set(now.timeIntervalSince1970, forKey: Keys.lastICloudSyncTime)
+    }
+
+    private func cloudDatabase(purpose: String) -> CKDatabase? {
+        CloudKitContainerAccess.privateDatabase(
+            containerIdentifier: CloudCookieFields.containerIdentifier,
+            purpose: purpose,
+            category: .cloudKit
+        )
     }
 
     /// 辅助类用于跟踪 Bonjour 发送状态

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Compatibility login declarations for older plugin manifests.
+///
+/// Twitch and Kick plugins already know how to consume host-managed cookies, but
+/// several released manifests do not declare `loginFlow`. Keep these fallbacks
+/// small and data-only so plugin authors can later move the same fields into
+/// manifest.json without changing app code.
+public enum PlatformLoginCompatibility {
+    public static func loginFlow(for manifest: LiveParsePluginManifest) -> ManifestLoginFlow? {
+        if let loginFlow = manifest.loginFlow {
+            return loginFlow
+        }
+
+        switch normalizedPluginId(manifest.pluginId) {
+        case "twitch":
+            return twitchLoginFlow()
+        case "kick":
+            return kickLoginFlow()
+        case "soop":
+            return soopLoginFlow()
+        default:
+            return nil
+        }
+    }
+
+    public static func auth(for manifest: LiveParsePluginManifest) -> ManifestAuth? {
+        if let auth = manifest.auth {
+            return auth
+        }
+        guard loginFlow(for: manifest) != nil else { return nil }
+        return ManifestAuth(
+            required: true,
+            credentialKinds: ["cookie"],
+            supportsStatusCheck: false,
+            supportsValidation: false
+        )
+    }
+
+    public static func requiresLogin(_ manifest: LiveParsePluginManifest) -> Bool {
+        if let required = manifest.auth?.required {
+            return required
+        }
+        return loginFlow(for: manifest) != nil
+    }
+
+    private static func twitchLoginFlow() -> ManifestLoginFlow {
+        ManifestLoginFlow(
+            kind: "webview",
+            loginURL: "https://www.twitch.tv/login",
+            cookieDomains: ["twitch.tv", "www.twitch.tv"],
+            authSignalCookies: ["auth-token"],
+            uidCookieNames: ["login", "name", "unique_id"],
+            successURLKeyword: "twitch.tv",
+            requiredCookieHint: "需要包含 auth-token，建议同时包含 login 或 unique_id。",
+            websiteHost: "www.twitch.tv"
+        )
+    }
+
+    private static func kickLoginFlow() -> ManifestLoginFlow {
+        ManifestLoginFlow(
+            kind: "webview",
+            loginURL: "https://kick.com/login",
+            cookieDomains: ["kick.com", "www.kick.com"],
+            authSignalCookies: ["kick_session", "XSRF-TOKEN"],
+            uidCookieNames: ["username", "user_id", "userId"],
+            successURLKeyword: "kick.com",
+            requiredCookieHint: "需要包含 kick_session，建议同时包含 XSRF-TOKEN。",
+            websiteHost: "kick.com"
+        )
+    }
+
+    private static func soopLoginFlow() -> ManifestLoginFlow {
+        ManifestLoginFlow(
+            kind: "webview",
+            loginURL: "https://login.sooplive.com/afreeca/login.php",
+            cookieDomains: [
+                "sooplive.co.kr",
+                "sooplive.com",
+                "afreecatv.com"
+            ],
+            authSignalCookies: [
+                "AuthTicket",
+                "PdboxTicket",
+                "RDB"
+            ],
+            uidCookieNames: ["uid", "user_id", "szBjId"],
+            successURLKeyword: "sooplive",
+            requiredCookieHint: "海外访问通常需要 AbroadChk=OK；19+ 房间还需要账号登录后的 AuthTicket/PdboxTicket 等 Cookie。",
+            websiteHost: "www.sooplive.com"
+        )
+    }
+
+    private static func normalizedPluginId(_ pluginId: String) -> String {
+        pluginId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginRegistry.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginRegistry.swift
@@ -52,7 +52,7 @@ public actor PlatformLoginRegistry {
         let manifests = discoverAllManifests()
         var entries: [LoginPlatformEntry] = []
         for manifest in manifests {
-            guard let loginFlow = manifest.loginFlow else { continue }
+            guard let loginFlow = PlatformLoginCompatibility.loginFlow(for: manifest) else { continue }
             let liveType = manifest.liveTypes.first ?? manifest.pluginId
             let displayName = manifest.displayName ?? manifest.pluginId
             let entry = LoginPlatformEntry(
@@ -60,7 +60,7 @@ public actor PlatformLoginRegistry {
                 displayName: displayName,
                 liveType: liveType,
                 loginFlow: loginFlow,
-                auth: manifest.auth,
+                auth: PlatformLoginCompatibility.auth(for: manifest),
                 version: manifest.version
             )
             entries.append(entry)

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceKeyService.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceKeyService.swift
@@ -30,9 +30,18 @@ public actor PluginSourceKeyService {
     /// 是否已成功加载过
     private var loaded = false
 
+    /// 内置兜底映射：keys.json 拉取失败时，官方订阅密钥仍可解析。
+    static let bundledFallbackKeyMap: [String: [String]] = [
+        "444222000": [
+            "https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/plugins.json",
+            "https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/plugins.json"
+        ]
+    ]
+
     /// 远程 keys.json 的备用地址（依次尝试）
     private let remoteURLs: [URL] = [
-        
+        URL(string: "https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json")!,
+        URL(string: "https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json")!
     ]
 
     private init() {}
@@ -44,6 +53,11 @@ public actor PluginSourceKeyService {
         // 已加载过则跳过
         guard !loaded else { return }
 
+        // 先放入稳定官方 key，远程成功后再覆盖/扩展。
+        if keyMap.isEmpty {
+            keyMap = Self.bundledFallbackKeyMap
+        }
+
         for url in remoteURLs {
             do {
                 let (data, response) = try await URLSession.shared.data(from: url)
@@ -52,7 +66,7 @@ public actor PluginSourceKeyService {
                     continue
                 }
                 let decoded = try JSONDecoder().decode(PluginSourceKeysResponse.self, from: data)
-                var map: [String: [String]] = [:]
+                var map = Self.bundledFallbackKeyMap
                 for entry in decoded.keys {
                     map[entry.key] = entry.urls
                 }
@@ -73,6 +87,6 @@ public actor PluginSourceKeyService {
     public func resolveKey(_ input: String) -> [String]? {
         let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        return keyMap[trimmed]
+        return keyMap[trimmed] ?? Self.bundledFallbackKeyMap[trimmed]
     }
 }

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceSyncService.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceSyncService.swift
@@ -49,8 +49,14 @@ public final class PluginSourceSyncService {
 
     /// 将插件源 URL 列表同步到 CloudKit
     public static func syncToCloudStatic(sourceURLs: [String]) async {
-        let container = CKContainer(identifier: CloudPluginSourceFields.containerIdentifier)
-        let database = container.privateCloudDatabase
+        guard let database = CloudKitContainerAccess.privateDatabase(
+            containerIdentifier: CloudPluginSourceFields.containerIdentifier,
+            purpose: "插件源 CloudKit 同步",
+            category: .plugin
+        ) else {
+            return
+        }
+
         let recordID = CKRecord.ID(recordName: CloudPluginSourceFields.fixedRecordName)
 
         if sourceURLs.isEmpty {
@@ -93,9 +99,16 @@ public final class PluginSourceSyncService {
             hasSyncedSources = false
             return
         }
+        guard let database = CloudKitContainerAccess.privateDatabase(
+            containerIdentifier: CloudPluginSourceFields.containerIdentifier,
+            purpose: "插件源 CloudKit 检查",
+            category: .plugin
+        ) else {
+            hasSyncedSources = false
+            syncedSourceURLs = []
+            return
+        }
 
-        let container = CKContainer(identifier: CloudPluginSourceFields.containerIdentifier)
-        let database = container.privateCloudDatabase
         let recordID = CKRecord.ID(recordName: CloudPluginSourceFields.fixedRecordName)
 
         do {

--- a/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/StreamBookmarkService.swift
+++ b/Shared/AngelLiveCore/Sources/AngelLiveCore/Services/StreamBookmarkService.swift
@@ -100,11 +100,13 @@ public final class StreamBookmarkService {
 
     /// 从 CloudKit 同步到本地
     public func syncFromCloud() async {
+        guard let database = cloudDatabase else { return }
+
         isLoading = true
         defer { isLoading = false }
 
         do {
-            let cloudBookmarks = try await fetchAllFromCloud()
+            let cloudBookmarks = try await fetchAllFromCloud(database: database)
             bookmarks = cloudBookmarks.sorted { $0.addedAt > $1.addedAt }
             saveToCache()
             syncError = nil
@@ -115,11 +117,17 @@ public final class StreamBookmarkService {
 
     // MARK: - CloudKit 操作
 
-    private var database: CKDatabase {
-        CKContainer(identifier: CloudStreamBookmarkFields.containerIdentifier).privateCloudDatabase
+    private var cloudDatabase: CKDatabase? {
+        CloudKitContainerAccess.privateDatabase(
+            containerIdentifier: CloudStreamBookmarkFields.containerIdentifier,
+            purpose: "网络链接收藏 CloudKit 同步",
+            category: .cloudKit
+        )
     }
 
     private func saveToCloud(_ bookmark: StreamBookmark) async throws {
+        guard let database = cloudDatabase else { return }
+
         let record = CKRecord(recordType: CloudStreamBookmarkFields.recordType)
         record.setValue(bookmark.id, forKey: CloudStreamBookmarkFields.bookmarkId)
         record.setValue(bookmark.title, forKey: CloudStreamBookmarkFields.title)
@@ -132,6 +140,8 @@ public final class StreamBookmarkService {
     }
 
     private func deleteFromCloud(_ bookmark: StreamBookmark) async throws {
+        guard let database = cloudDatabase else { return }
+
         let predicate = NSPredicate(format: "%K = %@", CloudStreamBookmarkFields.bookmarkId, bookmark.id)
         let query = CKQuery(recordType: CloudStreamBookmarkFields.recordType, predicate: predicate)
         let results = try await database.records(matching: query)
@@ -146,7 +156,7 @@ public final class StreamBookmarkService {
         try await saveToCloud(bookmark)
     }
 
-    private func fetchAllFromCloud() async throws -> [StreamBookmark] {
+    private func fetchAllFromCloud(database: CKDatabase) async throws -> [StreamBookmark] {
         let query = CKQuery(recordType: CloudStreamBookmarkFields.recordType, predicate: NSPredicate(value: true))
         let results = try await database.records(matching: query, resultsLimit: 99999)
 

--- a/Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift
+++ b/Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift
@@ -171,6 +171,285 @@ struct PluginErrorCardParsingTests {
     }
 }
 
+@Suite("Plugin source keys")
+struct PluginSourceKeyTests {
+
+    @Test("Official short key resolves without remote key index")
+    func officialShortKeyFallback() async {
+        let urls = await PluginSourceKeyService.shared.resolveKey("444222000")
+
+        #expect(urls?.count == 2)
+        #expect(urls?.first?.contains("PluginRelease/plugins.json") == true)
+        #expect(urls?.first?.contains("ghfast.top") == true)
+    }
+}
+
+@Suite("Platform login compatibility")
+struct PlatformLoginCompatibilityTests {
+
+    @Test("Twitch and Kick older manifests get host login fallback")
+    func fallbackLoginFlows() {
+        let twitch = manifest(pluginId: "twitch", liveType: "9")
+        let kick = manifest(pluginId: "kick", liveType: "10")
+        let soop = manifest(pluginId: "soop", liveType: "8")
+
+        #expect(PlatformLoginCompatibility.loginFlow(for: twitch)?.authSignalCookies == ["auth-token"])
+        #expect(PlatformLoginCompatibility.loginFlow(for: kick)?.authSignalCookies.contains("kick_session") == true)
+        #expect(PlatformLoginCompatibility.loginFlow(for: soop)?.loginURL == "https://login.sooplive.com/afreeca/login.php")
+        #expect(PlatformLoginCompatibility.loginFlow(for: soop)?.cookieDomains.contains("sooplive.co.kr") == true)
+        #expect(PlatformLoginCompatibility.loginFlow(for: twitch)?.userAgent == nil)
+        #expect(PlatformLoginCompatibility.requiresLogin(twitch))
+        #expect(PlatformLoginCompatibility.requiresLogin(kick))
+        #expect(PlatformLoginCompatibility.requiresLogin(soop))
+    }
+
+    @Test("Manifest loginFlow wins over fallback")
+    func manifestLoginFlowWins() {
+        let declared = ManifestLoginFlow(
+            loginURL: "https://example.com/login",
+            cookieDomains: ["example.com"],
+            authSignalCookies: ["sid"]
+        )
+        let twitch = manifest(pluginId: "twitch", liveType: "9", loginFlow: declared)
+
+        #expect(PlatformLoginCompatibility.loginFlow(for: twitch)?.loginURL == "https://example.com/login")
+        #expect(PlatformLoginCompatibility.loginFlow(for: twitch)?.authSignalCookies == ["sid"])
+    }
+
+    @Test("Manifest auth required false wins over fallback loginFlow")
+    func manifestAuthRequiredFalseWins() {
+        let twitch = manifest(
+            pluginId: "twitch",
+            liveType: "9",
+            auth: ManifestAuth(required: false, credentialKinds: ["cookie"])
+        )
+
+        #expect(PlatformLoginCompatibility.loginFlow(for: twitch) != nil)
+        #expect(PlatformLoginCompatibility.requiresLogin(twitch) == false)
+    }
+}
+
+@Suite("Platform cookie collector")
+struct PlatformCookieCollectorTests {
+
+    @Test("Domain matching covers sibling login hosts")
+    func domainMatching() {
+        let loginFlow = ManifestLoginFlow(
+            loginURL: "https://www.twitch.tv/login",
+            cookieDomains: ["twitch.tv"],
+            authSignalCookies: ["auth-token"]
+        )
+        let cookies = [
+            cookie(name: "auth-token", value: "token", domain: ".twitch.tv"),
+            cookie(name: "login", value: "streamer", domain: "www.twitch.tv"),
+            cookie(name: "sid", value: "other", domain: "example.com")
+        ]
+
+        let filtered = PlatformCookieCollector.filteredCookies(from: cookies, loginFlow: loginFlow)
+        #expect(filtered.map(\.name).sorted() == ["auth-token", "login"])
+        #expect(PlatformCookieCollector.containsAuthenticatedCookie(in: filtered, loginFlow: loginFlow))
+        #expect(PlatformCookieCollector.cookieHeader(from: filtered).contains("auth-token=token"))
+    }
+
+    @Test("Session cookie wins duplicate header selection")
+    func sessionCookieWinsDuplicateHeaderSelection() {
+        let cookies = [
+            cookie(name: "XSRF-TOKEN", value: "old-persistent", domain: ".kick.com"),
+            cookie(name: "XSRF-TOKEN", value: "fresh-session", domain: "kick.com", expires: nil)
+        ]
+
+        #expect(PlatformCookieCollector.cookieHeader(from: cookies) == "XSRF-TOKEN=fresh-session")
+    }
+}
+
+@Suite("Live image URL resolver")
+struct LiveImageURLResolverTests {
+
+    @Test("SOOP empty cover falls back to live preview CDN by room id")
+    func soopEmptyCoverFallback() {
+        let cover = LiveImageURLResolver.roomCoverURLString(
+            rawValue: "",
+            liveType: LiveType(rawValue: "8")!,
+            roomId: "294060425"
+        )
+
+        #expect(cover == "https://liveimg.sooplive.com/m/294060425?320")
+    }
+
+    @Test("SOOP legacy image domain is canonicalized")
+    func soopLegacyDomainCanonicalized() {
+        let cover = LiveImageURLResolver.roomCoverURLString(
+            rawValue: "http://liveimg.sooplive.co.kr/m/294060425?511",
+            liveType: LiveType(rawValue: "8")!,
+            roomId: "294060425"
+        )
+
+        #expect(cover == "https://liveimg.sooplive.com/m/294060425?511")
+    }
+
+    @Test("SOOP live preview URL can carry a refresh token")
+    func soopLivePreviewURLIncludesRefreshToken() {
+        let cover = LiveImageURLResolver.soopLivePreviewURLString(
+            roomId: "294060425",
+            refreshToken: "preview-1"
+        )
+
+        #expect(cover == "https://liveimg.sooplive.com/m/294060425?320&_al_preview=preview-1")
+    }
+
+    @Test("Non-SOOP empty cover stays empty")
+    func nonSOOPEmptyCover() {
+        let cover = LiveImageURLResolver.roomCoverURLString(
+            rawValue: "",
+            liveType: LiveType(rawValue: "13")!,
+            roomId: "294060425"
+        )
+
+        #expect(cover.isEmpty)
+    }
+
+    @Test("SOOP model falls back to avatar when broad number is unavailable")
+    func soopModelUsesAvatarFallbackWithoutBroadNumber() {
+        let room = LiveModel(
+            userName: "streamer",
+            roomTitle: "19+ room",
+            roomCover: "",
+            userHeadImg: "https://stimg.sooplive.com/LOGO/ci/cinnamoroll/cinnamoroll.jpg",
+            liveType: LiveType(rawValue: "8")!,
+            liveState: "1",
+            userId: "cinnamoroll",
+            roomId: "cinnamoroll",
+            liveWatchedCount: "0"
+        )
+
+        #expect(room.displayRoomCover == "https://stimg.sooplive.com/LOGO/ci/cinnamoroll/cinnamoroll.jpg")
+    }
+}
+
+@Suite("Playback initial selection")
+struct PlaybackInitialSelectionTests {
+
+    @Test("Prefers concrete CHZZK-like 1080p over Auto and lower variants")
+    func prefersHighestConcreteQuality() {
+        let playArgs = [
+            LiveQualityModel(cdn: "default", qualitys: [
+                quality(title: "Auto", qn: 0, url: "https://example.com/master.m3u8", liveType: "13"),
+                quality(title: "720p", qn: 720, url: "https://example.com/720.m3u8", liveType: "13"),
+                quality(title: "1080p", qn: 1080, url: "https://example.com/1080.m3u8", liveType: "13")
+            ])
+        ]
+
+        let selection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        #expect(selection?.qualityIndex == 2)
+        #expect(selection?.quality.title == "1080p")
+    }
+
+    @Test("Skips empty source placeholder when choosing initial stream")
+    func skipsEmptySourcePlaceholder() {
+        let playArgs = [
+            LiveQualityModel(cdn: "default", qualitys: [
+                quality(title: "原画", qn: 10_000, url: "", liveType: "13"),
+                quality(title: "1080p", qn: 1080, url: "https://example.com/1080.m3u8", liveType: "13")
+            ])
+        ]
+
+        let selection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        #expect(selection?.qualityIndex == 1)
+        #expect(selection?.quality.title == "1080p")
+    }
+
+    @Test("Skips audio-only stream when video stream is available")
+    func skipsAudioWhenVideoExists() {
+        let playArgs = [
+            LiveQualityModel(cdn: "default", qualitys: [
+                quality(title: "Audio", qn: 9999, url: "https://example.com/audio.m3u8", liveType: "13"),
+                quality(title: "720p", qn: 720, url: "https://example.com/720.m3u8", liveType: "13")
+            ])
+        ]
+
+        let selection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        #expect(selection?.qualityIndex == 1)
+        #expect(selection?.quality.title == "720p")
+    }
+
+    @Test("Allows refresh-only quality as initial stream candidate")
+    func allowsRefreshOnlyQualityCandidate() {
+        let playArgs = [
+            LiveQualityModel(cdn: "default", qualitys: [
+                quality(title: "720p", qn: 720, url: "https://example.com/720.m3u8", liveType: "13"),
+                quality(
+                    title: "原画",
+                    qn: 10_000,
+                    url: "",
+                    liveType: "13",
+                    playbackHints: LivePlaybackHints(selectionBehavior: .refreshOnSelect)
+                )
+            ])
+        ]
+
+        let selection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        #expect(selection?.qualityIndex == 1)
+        #expect(selection?.quality.title == "原画")
+    }
+}
+
+private func manifest(
+    pluginId: String,
+    liveType: String,
+    loginFlow: ManifestLoginFlow? = nil,
+    auth: ManifestAuth? = nil
+) -> LiveParsePluginManifest {
+    LiveParsePluginManifest(
+        pluginId: pluginId,
+        version: "1.0.0",
+        apiVersion: 1,
+        displayName: pluginId,
+        liveTypes: [liveType],
+        entry: "index.js",
+        auth: auth,
+        loginFlow: loginFlow
+    )
+}
+
+private func cookie(
+    name: String,
+    value: String,
+    domain: String,
+    expires: Date? = Date(timeIntervalSinceNow: 3600)
+) -> HTTPCookie {
+    var properties: [HTTPCookiePropertyKey: Any] = [
+        .name: name,
+        .value: value,
+        .domain: domain,
+        .path: "/"
+    ]
+    if let expires {
+        properties[.expires] = expires
+    }
+    return HTTPCookie(properties: properties)!
+}
+
+private func quality(
+    title: String,
+    qn: Int,
+    url: String,
+    liveType: String,
+    playbackHints: LivePlaybackHints? = nil
+) -> LiveQualityDetail {
+    LiveQualityDetail(
+        roomId: "room",
+        title: title,
+        qn: qn,
+        url: url,
+        liveCodeType: .hls,
+        liveType: LiveType(rawValue: liveType)!,
+        userAgent: nil,
+        headers: nil,
+        requestContext: nil,
+        playbackHints: playbackHints
+    )
+}
+
 private struct AnyCodingKey: CodingKey {
     let stringValue: String
     let intValue: Int?

--- a/Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift
+++ b/Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift
@@ -271,6 +271,64 @@ struct PluginCompatibilityPatchTests {
 
         #expect(try await runtime.pluginAPIVersion() == 1)
     }
+
+    @Test("Twitch patch resolves Just Chatting slug to game id and filters rooms")
+    func twitchPatchResolvesJustChattingSlug() async throws {
+        let runtime = JSRuntime(pluginId: "twitch-test")
+        try await runtime.evaluate(script: """
+        globalThis.__capturedCategoryIds = [];
+        globalThis.LiveParsePlugin = {
+          apiVersion: 1,
+          getCategories: function () { return []; },
+          getRooms: function () { return []; }
+        };
+        function _tw_loadCategoryCache() {
+          return { fresh: true, categories: [{ id: "509658", title: "谈天说地", biz: "just-chatting", icon: "" }] };
+        }
+        function _tw_saveCategoryCache() {}
+        function _tw_fetchTopGames() {
+          return [{ id: "509658", title: "谈天说地", biz: "just-chatting", icon: "" }];
+        }
+        function _tw_fetchAllStreamsPage() {
+          return { items: [] };
+        }
+        function _tw_fetchCategoryStreamsPage(categoryId) {
+          globalThis.__capturedCategoryIds.push(categoryId);
+          return {
+            items: [
+              { roomId: "a", userName: "A", liveType: "9", liveState: "1", biz: "509658" },
+              { roomId: "b", userName: "B", liveType: "9", liveState: "1", biz: "21779" }
+            ]
+          };
+        }
+        function _tw_dedupeRooms(rooms) { return rooms || []; }
+        """)
+
+        let twitch = manifest(pluginId: "twitch", version: "1.0.31", liveType: "9")
+        try await LiveParsePluginCompatibilityPatch.apply(to: runtime, manifest: twitch)
+        let result = try await runtime.callPluginFunction(
+            name: "getRooms",
+            payload: [
+                "id": "just-chatting",
+                "category": [
+                    "id": "just-chatting",
+                    "parentId": "root",
+                    "title": "谈天说地",
+                    "biz": "just-chatting"
+                ],
+                "page": 1
+            ]
+        )
+        let rooms = try #require(result as? [[String: Any]])
+
+        #expect(rooms.count == 1)
+        #expect(rooms.first?["roomId"] as? String == "a")
+
+        try await runtime.evaluate(
+            script: "globalThis.LiveParsePlugin.apiVersion = globalThis.__capturedCategoryIds[0] === '509658' ? 1 : 0;"
+        )
+        #expect(try await runtime.pluginAPIVersion() == 1)
+    }
 }
 
 @Suite("Platform cookie collector")

--- a/Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift
+++ b/Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift
@@ -274,6 +274,37 @@ struct PluginCompatibilityPatchTests {
 
     @Test("Twitch patch resolves Just Chatting slug to game id and filters rooms")
     func twitchPatchResolvesJustChattingSlug() async throws {
+        try await assertTwitchPatchResolvesJustChatting(
+            payload: [
+                "id": "just-chatting",
+                "category": [
+                    "id": "just-chatting",
+                    "parentId": "root",
+                    "title": "谈天说地",
+                    "biz": "just-chatting"
+                ],
+                "page": 1
+            ]
+        )
+    }
+
+    @Test("Twitch patch resolves category URL when id falls back to root")
+    func twitchPatchResolvesCategoryURL() async throws {
+        try await assertTwitchPatchResolvesJustChatting(
+            payload: [
+                "id": "root",
+                "category": [
+                    "id": "https://www.twitch.tv/directory/category/just-chatting",
+                    "parentId": "root",
+                    "title": "谈天说地",
+                    "biz": ""
+                ],
+                "page": 1
+            ]
+        )
+    }
+
+    private func assertTwitchPatchResolvesJustChatting(payload: [String: Any]) async throws {
         let runtime = JSRuntime(pluginId: "twitch-test")
         try await runtime.evaluate(script: """
         globalThis.__capturedCategoryIds = [];
@@ -306,19 +337,7 @@ struct PluginCompatibilityPatchTests {
 
         let twitch = manifest(pluginId: "twitch", version: "1.0.31", liveType: "9")
         try await LiveParsePluginCompatibilityPatch.apply(to: runtime, manifest: twitch)
-        let result = try await runtime.callPluginFunction(
-            name: "getRooms",
-            payload: [
-                "id": "just-chatting",
-                "category": [
-                    "id": "just-chatting",
-                    "parentId": "root",
-                    "title": "谈天说地",
-                    "biz": "just-chatting"
-                ],
-                "page": 1
-            ]
-        )
+        let result = try await runtime.callPluginFunction(name: "getRooms", payload: payload)
         let rooms = try #require(result as? [[String: Any]])
 
         #expect(rooms.count == 1)

--- a/Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift
+++ b/Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift
@@ -229,6 +229,50 @@ struct PlatformLoginCompatibilityTests {
     }
 }
 
+@Suite("Plugin compatibility patches")
+struct PluginCompatibilityPatchTests {
+
+    @Test("Twitch 1.0.31 category and room lists are redirected to website GQL")
+    func twitch1031UsesGQLListPatch() {
+        let twitch = manifest(pluginId: "twitch", version: "1.0.31", liveType: "9")
+        let script = LiveParsePluginCompatibilityPatch.script(for: twitch)
+
+        #expect(script?.contains("_tw_fetchTopGames") == true)
+        #expect(script?.contains("_tw_fetchAllStreamsPage") == true)
+        #expect(script?.contains("_tw_fetchCategoryStreamsPage") == true)
+    }
+
+    @Test("Other Twitch versions are left to the plugin")
+    func newerTwitchVersionsAreNotPatched() {
+        let twitch = manifest(pluginId: "twitch", version: "1.0.32", liveType: "9")
+
+        #expect(LiveParsePluginCompatibilityPatch.script(for: twitch) == nil)
+    }
+
+    @Test("Twitch patch evaluates inside JSRuntime")
+    func twitchPatchEvaluatesInsideJSRuntime() async throws {
+        let runtime = JSRuntime(pluginId: "twitch-test")
+        try await runtime.evaluate(script: """
+        globalThis.LiveParsePlugin = {
+          apiVersion: 1,
+          getCategories: function () { return []; },
+          getRooms: function () { return []; }
+        };
+        function _tw_fetchTopGames() {}
+        function _tw_fetchAllStreamsPage() {}
+        function _tw_fetchCategoryStreamsPage() {}
+        """)
+
+        let twitch = manifest(pluginId: "twitch", version: "1.0.31", liveType: "9")
+        try await LiveParsePluginCompatibilityPatch.apply(to: runtime, manifest: twitch)
+        try await runtime.evaluate(
+            script: "globalThis.LiveParsePlugin.apiVersion = globalThis.LiveParsePlugin.__angelLiveTwitchGQLListPatch === true ? 1 : 0;"
+        )
+
+        #expect(try await runtime.pluginAPIVersion() == 1)
+    }
+}
+
 @Suite("Platform cookie collector")
 struct PlatformCookieCollectorTests {
 
@@ -395,13 +439,14 @@ struct PlaybackInitialSelectionTests {
 
 private func manifest(
     pluginId: String,
+    version: String = "1.0.0",
     liveType: String,
     loginFlow: ManifestLoginFlow? = nil,
     auth: ManifestAuth? = nil
 ) -> LiveParsePluginManifest {
     LiveParsePluginManifest(
         pluginId: pluginId,
-        version: "1.0.0",
+        version: version,
         apiVersion: 1,
         displayName: pluginId,
         liveTypes: [liveType],

--- a/Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift
+++ b/Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift
@@ -162,6 +162,12 @@ open class KSOptions {
     public var userAgent: String = "libmpv"
     public var avOptions: [String: Any] = [:]
     public var formatContextOptions: [String: Any] = [:]
+    public var playerTypes: [MediaPlayerProtocol.Type] = [
+        KSOptions.firstPlayerType,
+        KSOptions.secondPlayerType
+    ].compactMap { $0 }
+    public var videoFilters: [Any] = []
+    public var audioFilters: [Any] = []
     public var decodeType: KSDecodeType = .software
     public var canStartPictureInPictureAutomaticallyFromInline: Bool = false
 
@@ -353,6 +359,10 @@ public class KSPlayerLayerBase: NSObject {
 
     public func resetPlayer() {
         stop()
+    }
+
+    public func reset() {
+        resetPlayer()
     }
 
     public func select(subtitleInfo info: MediaPlayerTrack?) {

--- a/Shared/AngelLiveDependencies/Sources/PlayerOptions.swift
+++ b/Shared/AngelLiveDependencies/Sources/PlayerOptions.swift
@@ -4,7 +4,7 @@ import CoreMedia
 public class PlayerOptions: KSOptions, @unchecked Sendable {
     public var syncSystemRate: Bool = false
 
-    nonisolated required public init() {
+    nonisolated public required override init() {
         super.init()
     }
 

--- a/TV/AngelLiveTVOS/Source/DetailPlayer/DetailPlayerView.swift
+++ b/TV/AngelLiveTVOS/Source/DetailPlayer/DetailPlayerView.swift
@@ -58,7 +58,7 @@ struct DetailPlayerView: View {
             )
         } else if roomInfoViewModel.currentPlayURL == nil {
             ZStack {
-                KFImage(URL(string: roomInfoViewModel.currentRoom.roomCover))
+                KFImage(URL(string: roomInfoViewModel.currentRoom.displayRoomCover))
                     .resizable()
                     .scaledToFill()
                     .frame(width: 1920, height: 1080)

--- a/TV/AngelLiveTVOS/Source/DetailPlayer/PlayerControlCardView.swift
+++ b/TV/AngelLiveTVOS/Source/DetailPlayer/PlayerControlCardView.swift
@@ -27,7 +27,7 @@ struct PlayerControlCardView: View {
                 changeRoom(playControlCardViewModel.liveModel)
             } label: {
                 ZStack(alignment: .bottom) {
-                    KFImage(URL(string: playControlCardViewModel.liveModel.roomCover))
+                    KFImage(URL(string: playControlCardViewModel.liveModel.displayRoomCover))
                         .placeholder {
                             Image("placeholder")
                                 .resizable()
@@ -36,7 +36,7 @@ struct PlayerControlCardView: View {
                         .resizable()
                         .frame(width: 320, height: 210)
                         .blur(radius: 10)
-                    KFImage(URL(string: playControlCardViewModel.liveModel.roomCover))
+                    KFImage(URL(string: playControlCardViewModel.liveModel.displayRoomCover))
                         .placeholder {
                             Image("placeholder")
                                 .resizable()

--- a/TV/AngelLiveTVOS/Source/DetailPlayer/RoomInfoViewModel.swift
+++ b/TV/AngelLiveTVOS/Source/DetailPlayer/RoomInfoViewModel.swift
@@ -161,7 +161,10 @@ final class RoomInfoViewModel {
                 tappedSelection: tappedSelection,
                 effectiveSelection: tappedSelection
             )
-            currentPlayQualityString = currentQuality.title
+            currentPlayQualityString = RoomPlaybackResolver.qualityDisplayTitle(
+                in: playArgs,
+                selection: tappedSelection
+            )
             currentPlayQualityQn = currentQuality.qn
             self.currentCdnIndex = cdnIndex
             self.currentQualityIndex = urlIndex
@@ -177,7 +180,10 @@ final class RoomInfoViewModel {
             effectiveSelection: effectiveSelection
         )
 
-        currentPlayQualityString = effectiveQuality.title
+        currentPlayQualityString = RoomPlaybackResolver.qualityDisplayTitle(
+            in: playArgs,
+            selection: effectiveSelection ?? tappedSelection
+        )
         currentPlayQualityQn = effectiveQuality.qn
         self.currentCdnIndex = effectiveSelection?.cdnIndex ?? cdnIndex
         self.currentQualityIndex = effectiveSelection?.qualityIndex ?? urlIndex
@@ -407,7 +413,11 @@ final class RoomInfoViewModel {
             showToast(false, title: "获取直播间信息失败")
             return
         }
-        self.changePlayUrl(cdnIndex: 0, urlIndex: 0)
+        let initialSelection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        self.changePlayUrl(
+            cdnIndex: initialSelection?.cdnIndex ?? 0,
+            urlIndex: initialSelection?.qualityIndex ?? 0
+        )
         //开一个定时，检查主播是否已经下播
         if appViewModel.playerSettingsViewModel.openExitPlayerViewWhenLiveEnd == true {
             if PlatformHostBehavior.supportsLiveEndPolling(for: currentRoom.liveType) {

--- a/TV/AngelLiveTVOS/Source/List/LiveCardView.swift
+++ b/TV/AngelLiveTVOS/Source/List/LiveCardView.swift
@@ -68,7 +68,7 @@ struct LiveCardView: View {
             ZStack(alignment: .topLeading) {
                 ZStack(alignment: .bottom) {
                     // 背景模糊层
-                    KFImage(URL(string: currentLiveModel.roomCover))
+                    KFImage(URL(string: currentLiveModel.displayRoomCover))
                         .placeholder {
                             placeholderImage
                         }
@@ -79,7 +79,7 @@ struct LiveCardView: View {
                         .clipped()
 
                     // 前景封面图
-                    KFImage(URL(string: currentLiveModel.roomCover))
+                    KFImage(URL(string: currentLiveModel.displayRoomCover))
                         .onFailure { error in
                             print("Image loading failed: \(error)")
                         }
@@ -140,7 +140,7 @@ struct LiveCardView: View {
     private func streamerInfoSection(currentLiveModel: LiveModel) -> some View {
         HStack(spacing: 12) {
             // 主播头像
-            KFImage(URL(string: currentLiveModel.userHeadImg))
+            KFImage(URL(string: currentLiveModel.displayUserHeadImg))
                 .placeholder {
                     Circle()
                         .fill(Color.gray.opacity(0.3))

--- a/TV/TopShelfExtension/ContentProvider.swift
+++ b/TV/TopShelfExtension/ContentProvider.swift
@@ -180,10 +180,10 @@ class ContentProvider: TVTopShelfContentProvider {
             item.title = streamer.roomTitle + " - " + streamer.userName
 
             // 设置封面图片
-            if let coverURL = URL(string: streamer.roomCover) {
+            if let coverURL = URL(string: streamer.displayRoomCover) {
                 item.setImageURL(coverURL, for: .screenScale1x)
                 item.setImageURL(coverURL, for: .screenScale2x)
-            } else if let headURL = URL(string: streamer.userHeadImg) {
+            } else if let headURL = URL(string: streamer.displayUserHeadImg) {
                 item.setImageURL(headURL, for: .screenScale1x)
                 item.setImageURL(headURL, for: .screenScale2x)
             }

--- a/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
+++ b/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
@@ -34,6 +34,7 @@
 - 新增 `LiveParsePluginCompatibilityPatch`，只对 `twitch@1.0.31` 注入兼容脚本。
 - 兼容脚本复用插件内已有的 `_tw_fetchTopGames`、`_tw_fetchAllStreamsPage`、`_tw_fetchCategoryStreamsPage`，把分类和直播间列表切回 `https://gql.twitch.tv/gql`。
 - 兼容 Twitch 分类 URL 的 slug，例如 `just-chatting` 会解析回游戏 ID `509658`，并按房间 `biz` 再做一次分类过滤。
+- 即使宿主路径传入 `id=root`，也会优先读取 `category.id/category.biz` 中的真实分类。
 - 补丁按精确版本命中，后续上游插件升级到 1.0.32 或其它版本时自动停止注入。
 
 ### 3. CHZZK 默认清晰度
@@ -108,6 +109,7 @@
 - CHZZK 类清晰度列表默认选择 1080p，跳过 Auto、空 URL 占位和 audio-only。
 - `twitch@1.0.31` 兼容脚本只命中该版本，并可在宿主 JavaScriptCore 中执行。
 - Twitch `just-chatting` slug 能解析到 `509658`，且只返回该分类房间。
+- Twitch 分类 URL 在 `id=root` 的兜底路径下也能解析到 `509658`。
 
 ## 兼容边界
 
@@ -133,7 +135,7 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device 
 
 结果：
 
-- Core 测试通过：`34 tests passed`。
+- Core 测试通过：`35 tests passed`。
 - iOS 26.1 真机 Debug 构建、安装、启动通过。
 - 个人开发签名无 iCloud entitlement 时可正常进入 App。
 - 输入订阅密钥 `444222000` 后可安装官方插件。

--- a/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
+++ b/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
@@ -2,323 +2,120 @@
 
 日期：2026-05-16
 
-## 审查范围
+## 本次重点
 
-本次修改围绕 3 个用户可见问题：
+本 PR 主要修复三类线上可见问题：
 
-- Twitch / Kick Cookie 登录无法稳定保存或无法出现在登录入口。
-- CHZZK 默认播放清晰度被降到 Auto / 低清晰度。
-- SOOP Cookie 登录后部分直播间没有预览图。
-- SOOP 19x 直播间返回灰色年龄占位图，登录后仍缺少真实实时封面。
-- SOOP 需要列表筛选能力：全部 / 只显示 19x / 只显示非 19x。
-- iOS 真机 SOOP 19x 播放页左键点击不弹控制层、画面闪烁或卡死。
-- Twitch 1.0.31 点击平台后分类列表加载失败，报 `missing clientId or accessToken in token server response`。
-- iOS 真机个人开发签名缺少 iCloud entitlement 时启动闪退。
-- 官方订阅密钥 `444222000` 未解析，误走普通视频收藏。
+- Twitch / Kick / SOOP 的 Cookie 登录与宿主登录入口兼容。
+- CHZZK 默认进入低清晰度或 Auto 的问题。
+- SOOP 登录后部分直播间，尤其 19x 直播间，预览图、播放控制和筛选体验异常。
 
-同时修复代码审查发现的问题：
+真机回归过程中额外修复：
 
-- macOS 平台详情页登录入口把 `liveType` 当作 `pluginId` 传入，导致 SOOP 等平台登录页无法定位。
-- 初始清晰度选择可能选中空 URL 的“原画 / Best”占位项，导致播放器没有可播放地址。
-- ops4.7 复审后补修：音频轨不参与默认清晰度竞争、macOS Cookie 保存失败时登录状态置假、manifest 显式 `auth.required=false` 优先于宿主兜底、session Cookie 去重优先级、SOOP 兜底日志、tvOS 清晰度展示标题与 iOS/macOS 对齐。
-- 真机回归后补修：所有 CloudKit 入口在初始化 `CKContainer(identifier:)` 前先判断签名是否包含目标 iCloud 容器，避免个人开发证书无 iCloud 能力时启动或同步入口崩溃；订阅密钥服务补齐官方 `keys.json` 地址和 `444222000` 内置兜底。
-- SOOP 19x 复测后补修：只对 19x 占位封面做一次实时截图缓存，非 19x 房间不再 force refresh；首次进入 SOOP 拉取前三页并预热 19x 截图，滚动时继续按窗口预加载未处理过的 19x 房间。
-- SOOP 19x 筛选补修：iOS SOOP 分类页新增“全部 / 19x / 非19x”三段筛选；筛选结果基于同一套 19x 占位图检测状态，不改插件协议和持久化模型。
-- Twitch 1.0.31 补修：宿主加载插件后对该版本精确注入兼容脚本，把分类和房间列表从 Helix token server 路径切回插件已内置的 Twitch website GQL helper。
+- Twitch 1.0.31 分类列表加载失败，报 `missing clientId or accessToken in token server response`。
+- 个人开发签名不包含 iCloud entitlement 时 App 启动或同步入口崩溃。
+- 官方订阅密钥 `444222000` 未稳定解析。
 
-## 核心改动
+## 关键修复
 
-### 1. 平台登录兼容修复
+### 1. 平台登录和 Cookie
 
-新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift`：
+- 新增宿主侧登录兼容层，旧 manifest 未声明 `loginFlow` 时，Twitch / Kick / SOOP 仍能进入账号管理和 Web 登录。
+- iOS / macOS 登录面板统一使用 `PlatformCookieCollector` 收集、过滤、去重 Cookie。
+- Web 登录页清理站点数据后再重新登录，避免旧 Cookie 干扰。
+- iOS 登录 WebView 改为移动 Safari 风格 UA，避免 Twitch 提示“不支持您的浏览器”。
+- iOS / macOS 都接管 `target=_blank` / `window.open`，SOOP 的 Apple / Google 登录按钮可以在当前 WebView 内跳转。
+- manifest 显式声明 `auth.required=false` 时优先于宿主 fallback，避免以后插件作者显式开放匿名模式时被宿主覆盖。
 
-- 为旧版 manifest 缺少 `loginFlow` 的平台提供宿主侧兼容声明。
-- 覆盖平台：`twitch`、`kick`、`soop`。
-- Twitch 登录 URL：`https://www.twitch.tv/login`。
-- Kick 登录 URL：`https://kick.com/login`。
-- SOOP 登录 URL：`https://login.sooplive.com/afreeca/login.php`。
-- SOOP Cookie 域覆盖 `sooplive.co.kr`、`sooplive.com`、`afreecatv.com`。
+### 2. Twitch 1.0.31 列表加载
 
-修改 `LiveParsePluginManifest.requiresLogin`：
+- `twitch@1.0.31` 发布说明是 website GQL，但导出的 `getCategories` / `getRooms` 仍走 Helix token server。
+- 当 token server 返回缺少 `clientId/accessToken` 时，平台页会直接加载失败。
+- 新增 `LiveParsePluginCompatibilityPatch`，只对 `twitch@1.0.31` 注入兼容脚本。
+- 兼容脚本复用插件内已有的 `_tw_fetchTopGames`、`_tw_fetchAllStreamsPage`、`_tw_fetchCategoryStreamsPage`，把分类和直播间列表切回 `https://gql.twitch.tv/gql`。
+- 补丁按精确版本命中，后续上游插件升级到 1.0.32 或其它版本时自动停止注入。
 
-- 由原先只看 manifest 原始字段，改为走 `PlatformLoginCompatibility.requiresLogin`。
-- 旧插件即使没有声明登录字段，也可以进入账号管理和登录流程。
+### 3. CHZZK 默认清晰度
 
-修改 `PlatformLoginRegistry`：
+- 新增 `RoomPlaybackResolver.preferredInitialSelection(in:)`。
+- 默认播放不再盲选插件返回的第一项，而是按可播放性和清晰度评分选择初始项。
+- 明确分辨率优先于 Auto / 自适应。
+- Source / Best / 原画优先级最高，但空 URL 占位项不会抢默认播放。
+- audio-only 音频轨不参与默认视频清晰度竞争。
+- iOS / tvOS / macOS 三端接入同一选择逻辑，tvOS 展示标题也与 iOS / macOS 对齐。
 
-- 使用兼容层返回的 `loginFlow` 和 `auth`。
-- 登录入口列表可包含 Twitch / Kick / SOOP 旧 manifest。
+### 4. SOOP 预览图和 19x
 
-修复 `macOS/AngelLiveMacOS/Views/PlatformDetailView.swift`：
+- 新增 `LiveImageURLResolver`，统一标准化封面和头像 URL。
+- SOOP 空封面且 `roomId` 为数字时兜底到 `https://liveimg.sooplive.com/m/{roomId}?320`。
+- SOOP 旧图床域名和 http 链接统一 canonicalize，减少 Kingfisher / ATS 加载失败。
+- 19x 灰色年龄占位图通过封面 CDN 内容长度识别。
+- 只有识别为 19x 占位图的房间才解析播放地址并截取首帧；非 19x 不做实时刷新。
+- 19x 实时封面只写入 Kingfisher 内存缓存，key 保持稳定，不污染收藏、历史或 CloudKit 持久化字段。
+- 首次进入 SOOP 会预取前三页并预热 19x 封面；向下滚动时继续预加载新出现的 19x 房间。
+- 已检测或已加载过的房间不会因为下拉刷新、点击刷新或切换筛选重复拉流截图。
+- iOS SOOP 分类页新增筛选：`全部 / 19x / 非19x`。
 
-- 平台详情页登录弹窗改为传 `viewModel.platform.pluginId`。
-- 避免 `soop` 平台被错误传成 `8` 后查不到登录入口。
+### 5. SOOP 19x 播放控制
 
-### 2. Cookie 收集与 Web 登录修复
+- 移除 VLC drawable 上的 SwiftUI `onTapGesture`，避免 19x 流播放时点击事件和 VLCKit drawable 抢占。
+- 控制层改用全屏透明 tap catcher：隐藏时点击显示，显示时点击空白处隐藏。
+- VLC 同一 media fingerprint 下不再从 `.paused` 强行恢复播放，只处理 `.stopped` / `.error` 恢复。
+- stop / media 释放移到后台队列，降低主线程卡顿和闪退风险。
 
-新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`：
+### 6. 真机签名和订阅源
 
-- 统一 iOS / macOS 的 Cookie 过滤、去重、签名和 UID 提取逻辑。
-- 支持同站兄弟域匹配，例如 `.twitch.tv` / `www.twitch.tv`、`kick.com` / `www.kick.com`。
-- Cookie header 去重时优先非空、当前 session、域名和 path 更具体的 Cookie，再比较长有效期。
+- 新增 `CloudKitContainerAccess`，访问命名 CloudKit 容器前先检查当前签名是否包含目标 iCloud 容器。
+- 个人开发团队不支持 iCloud / Push 时，本地 Debug 包跳过 CloudKit 同步，不再在 `CKContainer(identifier:)` 崩溃。
+- 收藏、书签、插件源同步、平台凭证同步都接入该 guard。
+- `PluginSourceKeyService` 补齐官方 `keys.json` 地址，并内置 `444222000` 兜底映射。
 
-修改 iOS 登录面板 `PlatformLoginWebSheet.swift`：
+## 主要文件
 
-- 使用 `PlatformCookieCollector.filteredCookies` 收集相关域名 Cookie。
-- 使用 `PlatformCookieCollector.cookieHeader` 生成最终 Cookie 字符串。
-- 使用 `PlatformCookieCollector.containsAuthenticatedCookie` 判断是否已登录。
-- 重新登录 / 退出登录时清理相关域名的 Cookie 和 WebKit 站点数据。
-- 登录 WebView 默认使用移动 Safari 风格 UA，不再让旧 Twitch/Kick/SOOP 兜底流强制注入桌面 Chromium UA，避免 Twitch 把 WKWebView 判定成“不支持的浏览器”。
-- 开启 `javaScriptCanOpenWindowsAutomatically`，并用 `WKUIDelegate` 接管 `target=_blank` / `window.open`，让 SOOP 的 Apple / Google 第三方登录按钮在当前 WebView 内继续跳转。
+新增：
 
-修改 macOS 登录面板 `MacPlatformLoginWebSheet.swift`：
-
-- 同步 iOS 的统一 Cookie 收集逻辑。
-- 打开登录页时立即轮询一次 Cookie，避免登录完成后等待下一轮定时器。
-- “重新登录”和“退出登录”会清理相关平台网页登录缓存，避免旧账号 Cookie 干扰。
-- Cookie 保存返回过期、无效或网络错误时显式把 `isLoggedIn` 置为 `false`，避免 UI 留在“账号信息”页。
-- 登录 WebView 默认使用桌面 Safari 风格 UA，并同步处理第三方登录新窗口，保持 iOS / macOS 登录行为一致。
-
-### 3. JSRuntime Cookie 注入修复
-
-修改 `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift`：
-
-- 修复 `cookieInject` 写入 body 后又被 `envelope.body` 覆盖的问题。
-- 现在 body 注入结果会保留到最终请求。
-- 影响场景：插件需要把 Cookie 中的字段注入请求 body 时，之前会丢失。
-
-### 3.1. Twitch 1.0.31 列表加载修复
-
-新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift`：
-
-- 宿主在插件入口脚本执行并通过 `apiVersion` 检查后，按 manifest 精确版本注入兼容脚本。
-- 当前只命中 `twitch@1.0.31`，不会影响后续上游插件版本。
-- Twitch 1.0.31 发布说明写的是 website GQL，但导出的 `getCategories` / `getRooms` 仍调用 Helix token server；当 token server 返回缺少 `clientId/accessToken` 时，平台页直接失败。
-- 兼容脚本复用插件包内已存在的 `_tw_fetchTopGames`、`_tw_fetchAllStreamsPage`、`_tw_fetchCategoryStreamsPage`，让分类、全部直播和分类直播列表都走 `https://gql.twitch.tv/gql`。
-- 保留原插件分类缓存和房间去重 helper；若上游 helper 不存在才回退到原方法，便于问题定位。
-
-### 4. SOOP 直播间预览图修复
-
-新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift`：
-
-- 统一标准化直播间封面和头像 URL。
-- 支持：
-  - 去掉 JSON 转义中的 `\/`。
-  - `//host/path` 补 `https:`。
-  - `host/path` 补 `https://`。
-  - SOOP 旧图床域 `liveimg.sooplive.co.kr` 统一到 `liveimg.sooplive.com`。
-  - SOOP 图床 `http` 自动升级为 `https`。
-- 当 SOOP 房间 `roomCover` 为空且 `roomId` 是数字时，兜底生成：
-  - `https://liveimg.sooplive.com/m/{roomId}?320`
-- 命中 SOOP 兜底时输出 `[ImageResolver][SOOP] fallback=...` 调试日志，便于真机回归判断是否命中。
-
-修改 `LiveParseJSPlatformManager.PluginRoomDTO.toLiveModel`：
-
-- 插件返回的 `roomCover` 和 `userHeadImg` 在进入 `LiveModel` 前先做标准化。
-
-新增 `LiveModel` 展示扩展：
-
-- `displayRoomCover`
-- `displayUserHeadImg`
-
-所有 UI 图片加载改用展示扩展，避免旧缓存或未标准化 URL 继续导致图片失败。
-
-iOS SOOP 19x 实时封面补充：
-
-- `PlatformDetailViewModel` 首次进入 SOOP 分类时预取前三页房间列表，避免 19x 房间只在滚动后才进入候选池。
-- SOOP `liveimg.sooplive.com/m/{roomId}` URL 统一稳定为 `?320`，不再给所有房间追加 `_al_preview` 时间戳。
-- 非 19x 房间只走普通 Kingfisher 缓存，不做实时截图、不做强制刷新。
-- 19x 判定通过封面 CDN 的 `HEAD/GET` 内容长度识别灰色年龄占位图；只有命中占位图的房间才会解析播放地址并截取首帧。
-- 生成的实时封面只写入 Kingfisher 内存缓存，key 为稳定的 `https://liveimg.sooplive.com/m/{roomId}?320`，不改写收藏和 CloudKit 持久化字段。
-- ViewModel 记录已检测和正在处理的 `roomId`，下拉刷新、点击刷新或重复进入同一列表不会对已处理房间二次拉流截图。
-- `RoomListViewController.willDisplay` 在滚动时把后续窗口交给 ViewModel，继续预加载新出现的 19x 房间。
-- 真机日志已确认 19x 写入稳定 key，例如 `https://liveimg.sooplive.com/m/294067533?320`、`https://liveimg.sooplive.com/m/294050349?320`。
-
-iOS SOOP 19x 筛选补充：
-
-- `SubCategoryViewController` 仅在 SOOP 平台显示三段筛选控件：`全部`、`19x`、`非19x`。
-- `PlatformDetailViewModel` 保留原始全量 `roomListCache`，新增按分类读取的 `filteredRoomList(...)`，避免筛选破坏分页和缓存。
-- 19x / 非19x 状态来自 `liveimg.sooplive.com/m/{roomId}?320` 的占位图检测；未知状态不会被放进 19x 或非19x筛选结果，检测完成后通过通知刷新列表。
-- 切换筛选时会立即触发当前分类首屏窗口的 19x 状态检测；滚动到列表后续位置时继续检测附近窗口。
-- 已检测过的 `roomId` 不会因为切换筛选、下拉刷新或点击刷新重复进入检测和拉流截图流程。
-
-iOS SOOP 19x 播放控制补充：
-
-- `UnifiedPlayerControlOverlay` 增加全屏透明 tap catcher，控制层隐藏时点击显示，显示时点击空白处隐藏。
-- `PlayerContainerView` 移除 VLC drawable 上的 SwiftUI `onTapGesture`，避免 VLCKit drawable 与 SwiftUI 同时争抢 19x 流点击事件。
-- `VLCVideoPlayerView` 在同一 media fingerprint 下不再从 `.paused` 强行恢复播放，只处理 `.stopped` / `.error` 恢复；销毁和 stop 时把 VLCKit stop/media 释放放到后台队列，减少主线程卡顿和闪退风险。
-
-### 5. CHZZK 默认清晰度修复
-
-修改 `Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift`：
-
-- 新增 `preferredInitialSelection(in:)`。
-- 默认播放不再盲目使用插件返回的第一个清晰度。
-- 清晰度评分规则：
-  - `audio` / `音频` 最低。
-  - `auto` / `自适应` 低于明确分辨率。
-  - `source` / `best` / `原画` 最高。
-  - `1080p`、`720p` 等按解析出的高度排序。
-  - 没有高度时回退 `qn`。
-- 只在可直接播放或声明 `refreshOnSelect` 的清晰度中比较。
-- 避免空 URL 的“原画 / Best”占位项抢占默认播放。
-- 音频轨不会参与初始默认清晰度竞争；如果没有任何视频候选，仍保持旧逻辑的首项兜底。
-
-修改 iOS / tvOS / macOS 的 `RoomInfoViewModel`：
-
-- 初次拿到 `playArgs` 后使用 `preferredInitialSelection`。
-- 手动切换清晰度仍保留原有路径。
-- tvOS 展示当前清晰度时改用 `qualityDisplayTitle(in:selection:)`，同名不同流类型时和 iOS / macOS 一样追加 HLS / FLV 区分。
-
-### 6. VLC fallback 构建兼容
-
-当前默认 KSPlayer 依赖链会解析 `https://github.com/TracyPlayer/FFmpegKit`，该远端在本次验证时不可用。为了能在 Xcode 26.5 上完成本地编译验证，使用仓库已有的 `USE_VLC=1` fallback 路径。
-
-补齐 fallback 与真实 KSPlayer 的最小接口差异：
-
-- `Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift`
-  - `KSOptions.playerTypes`
-  - `KSOptions.videoFilters`
-  - `KSOptions.audioFilters`
-  - `KSPlayerLayerBase.reset()`
-- `Shared/AngelLiveDependencies/Sources/PlayerOptions.swift`
-  - `init()` 显式标记 `override`，兼容 fallback 下 `KSOptions` 的公开初始化器。
-- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift`
-  - 增加 `isLocked` 状态，和真实播放器模型对齐。
-
-### 7. 真机签名兼容与订阅密钥修复
-
-新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift`：
-
-- 在访问命名 CloudKit 容器前统一判断签名能力。
-- iOS / tvOS Debug 或 AdHoc 包通过 `embedded.mobileprovision` 读取 `com.apple.developer.icloud-container-identifiers`。
-- 如果当前签名没有 `iCloud.icloud.dev.igod.simplelive`，直接跳过对应 CloudKit 操作并输出日志。
-- App Store 包通常没有 `embedded.mobileprovision`，该路径仍信任正式签名 entitlement。
-
-接入该 guard 的 CloudKit 入口：
-
-- `FavoriteService`
-- `StreamBookmarkService`
-- `PluginSourceSyncService`
-- `PlatformCredentialSyncService`
-
-修复效果：
-
-- 个人开发团队不支持 iCloud / Push 的本地真机包可以正常启动。
-- 缺少 iCloud entitlement 时不再在 `CKContainer(identifier:)` 处触发 `EXC_BREAKPOINT / SIGTRAP`。
-- 本地收藏、插件安装、Cookie 登录仍可继续使用；仅跳过 iCloud 同步。
-
-修改 `PluginSourceKeyService`：
-
-- 补齐远程 `keys.json` 地址：
-  - `https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json`
-  - `https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json`
-- 增加官方密钥 `444222000` 的内置兜底映射。
-- 远程 keys 拉取失败时，`444222000` 仍会解析到官方插件索引，不会误当成普通视频地址。
-
-## 涉及文件
-
-### 新增文件
-
-- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift`
-- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift`
-- `docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md`
 
-### Shared / Core 修改
+重点修改：
 
-- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParseLoadedPlugin.swift`
-- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginManifest.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginRegistry.swift`
-- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/FavoriteService.swift`
-- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCredentialSyncService.swift`
-- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceKeyService.swift`
-- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceSyncService.swift`
-- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/StreamBookmarkService.swift`
-- `Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift`
-
-### Shared / Dependencies 修改
-
-- `Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift`
-- `Shared/AngelLiveDependencies/Sources/PlayerOptions.swift`
-
-### iOS 修改
-
-- `iOS/AngelLive/AngelLive/FullUI/Components/LiveRoomCard.swift`
-- `iOS/AngelLive/AngelLive/Common/PlayerCore/VLCVideoPlayerView.swift`
-- `iOS/AngelLive/AngelLive/FullUI/Managers/NowPlayingManager.swift`
 - `iOS/AngelLive/AngelLive/FullUI/ViewModels/PlatformDetailViewModel.swift`
-- `iOS/AngelLive/AngelLive/FullUI/ViewModels/RoomInfoViewModel.swift`
-- `iOS/AngelLive/AngelLive/FullUI/Views/DetailPlayerView.swift`
-- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerContainerView.swift`
-- `iOS/AngelLive/AngelLive/FullUI/Views/Player/UnifiedPlayerControlOverlay.swift`
-- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift`
-- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/VerticalLiveControllerView.swift`
-- `iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoSheet.swift`
-- `iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoView.swift`
-- `iOS/AngelLive/AngelLive/FullUI/Views/Setting/PlatformLoginWebSheet.swift`
 - `iOS/AngelLive/AngelLive/FullUI/Views/UIKit/ViewControllers/RoomListViewController.swift`
-
-### tvOS 修改
-
-- `TV/AngelLiveTVOS/Source/DetailPlayer/DetailPlayerView.swift`
-- `TV/AngelLiveTVOS/Source/DetailPlayer/PlayerControlCardView.swift`
-- `TV/AngelLiveTVOS/Source/DetailPlayer/RoomInfoViewModel.swift`
-- `TV/AngelLiveTVOS/Source/List/LiveCardView.swift`
-- `TV/TopShelfExtension/ContentProvider.swift`
-
-### macOS 修改
-
-- `macOS/AngelLiveMacOS/ViewModels/RoomInfoViewModel.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/UIKit/ViewControllers/SubCategoryViewController.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Setting/PlatformLoginWebSheet.swift`
 - `macOS/AngelLiveMacOS/Views/MacPlatformLoginWebSheet.swift`
 - `macOS/AngelLiveMacOS/Views/PlatformDetailView.swift`
-- `macOS/AngelLiveMacOS/Views/PlayerControlView.swift`
+- 三端 `RoomInfoViewModel`
 
-## 新增测试覆盖
+## 测试覆盖
 
-修改 `Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift`：
+新增或更新的 Core 测试覆盖：
 
-- `PlatformLoginCompatibilityTests`
-  - 旧 Twitch / Kick / SOOP manifest 能获得宿主登录兜底。
-  - manifest 自带 `loginFlow` 时优先使用 manifest，不被兜底覆盖。
-- `PluginSourceKeyTests`
-  - 官方短密钥 `444222000` 不依赖远程 keys 索引也能解析到官方插件索引。
-- `PlatformCookieCollectorTests`
-  - 兄弟域 Cookie 能正确过滤。
-  - 登录信号 Cookie 能被识别。
-  - Cookie header 能正确生成。
-  - 同名 Cookie 去重时 session Cookie 优先于旧 persistent Cookie。
-- `LiveImageURLResolverTests`
-  - SOOP 空封面生成预览 CDN URL。
-  - SOOP 旧图床域名 canonicalize。
-  - 非 SOOP 空封面保持为空。
-- `PlaybackInitialSelectionTests`
-  - CHZZK 类 Auto / 720p / 1080p 列表默认选 1080p。
-  - 空 URL 的“原画”占位项不会被默认选中。
-  - 有视频候选时跳过 audio-only 音频轨。
-  - `refreshOnSelect` 的高画质项即使 URL 为空，仍允许作为初始候选。
-- `PlatformLoginCompatibilityTests`
-  - manifest 显式声明 `auth.required=false` 时优先于宿主 fallback。
-- `PluginCompatibilityPatchTests`
-  - `twitch@1.0.31` 会生成 GQL 列表兼容脚本。
-  - `twitch@1.0.32` 等其它版本不被宿主覆盖。
-  - 兼容脚本可在宿主 `JSRuntime` / JavaScriptCore 中正常执行。
+- Twitch / Kick / SOOP 旧 manifest 登录 fallback。
+- manifest 显式 `auth.required=false` 优先于宿主 fallback。
+- Cookie 跨域过滤、登录信号识别和 session Cookie 去重优先级。
+- 官方订阅密钥 `444222000` 兜底解析。
+- SOOP 封面 URL 标准化和空封面兜底。
+- CHZZK 类清晰度列表默认选择 1080p，跳过 Auto、空 URL 占位和 audio-only。
+- `twitch@1.0.31` 兼容脚本只命中该版本，并可在宿主 JavaScriptCore 中执行。
 
-## 兼容性说明
+## 兼容边界
 
-- 兼容层是 data-only，后续插件 manifest 正式声明 `loginFlow` 后，会自动优先使用 manifest 字段。
-- SOOP 预览图兜底只在 `liveType` 为 `8` 或 `soop`，且 `roomId` 为纯数字时启用。
-- SOOP 19x 实时截图只在 iOS 列表层启用；非 19x 房间不会进入播放地址解析或截图流程。
-- SOOP 19x 筛选只在 iOS SOOP 分类页展示；其它平台和 tvOS/macOS 不显示该控件。
-- SOOP 19x 截图只作为 Kingfisher 内存缓存存在，App 重启后会重新按当前直播状态检测，不污染收藏、历史或 iCloud 数据。
-- UI 层保留原 `LiveModel.roomCover` / `userHeadImg` 字段，只新增展示用扩展，避免影响持久化模型结构。
-- 清晰度选择只改变初始默认项，用户手动切换清晰度流程未重写。
-- Twitch 列表兼容补丁只作用于 `twitch@1.0.31`，上游发布 1.0.32 或 manifest 版本变更后自动停止注入。
+- 登录兼容层只作为旧 manifest 兜底；插件 manifest 明确声明时优先使用插件声明。
+- Twitch 列表补丁只作用于 `twitch@1.0.31`。
+- SOOP 19x 实时封面只在 iOS 列表层启用。
+- 非 19x SOOP 房间不做实时截图、不强制刷新封面。
+- SOOP 19x 截图只进内存缓存，不写入收藏、历史、CloudKit。
+- CHZZK 清晰度修复只改变初始默认项，不改变用户手动切换流程。
+- 缺少 iCloud entitlement 时只跳过 CloudKit 同步，本地功能继续可用。
 
 ## 验证结果
 
@@ -327,38 +124,25 @@ iOS SOOP 19x 播放控制补充：
 ```bash
 git diff --check
 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Shared/AngelLiveCore
-DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer USE_VLC=1 xcodebuild build -workspace AngelLive.xcworkspace -scheme AngelLive -configuration Debug -destination 'platform=iOS,id=00008130-000204881E6A001C' -allowProvisioningUpdates -skipPackagePluginValidation
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer USE_VLC=1 xcodebuild build -workspace AngelLive.xcworkspace -scheme AngelLive -configuration Debug -destination 'platform=iOS,id=00008130-000204881E6A001C' -allowProvisioningUpdates -skipPackagePluginValidation -quiet
 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device install app --device 6F726895-0F44-53B8-9291-C68C6C5B11A2 /Users/bing/Library/Developer/Xcode/DerivedData/AngelLive-gcijnxzpyclukqgalnuqneqbaqcp/Build/Products/Debug-iphoneos/AngelLive.app
 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device process launch --device 6F726895-0F44-53B8-9291-C68C6C5B11A2 --terminate-existing --console com.anlonely.AngelLiveTest
 ```
 
 结果：
 
-- `git diff --check` 通过。
-- Xcode 工具链直接运行 Core 测试通过：`33 tests passed`。
-- iOS 26.1 真机 Debug 构建通过：`** BUILD SUCCEEDED **`。
-- iOS 26.1 真机安装和 console 启动通过。
+- Core 测试通过：`33 tests passed`。
+- iOS 26.1 真机 Debug 构建、安装、启动通过。
+- 个人开发签名无 iCloud entitlement 时可正常进入 App。
+- 输入订阅密钥 `444222000` 后可安装官方插件。
+- SOOP 19x 播放控制真机复测：点击画面可弹出控制层，不再持续闪烁或卡死。
+- SOOP 19x 实时封面真机日志确认写入稳定 key：`https://liveimg.sooplive.com/m/{roomId}?320`。
+- Twitch 1.0.31 真机日志确认 `getCategories` / `getRooms` 均请求 `https://gql.twitch.tv/gql`，HTTP 200，分类和直播间列表成功返回。
 
-真机状态：
+## 建议重点审查
 
-- Xcode 26.5 能识别已连接 iPhone 15 Pro，设备系统为 iOS 26.1，开发者模式已启用。
-- 使用本地测试 bundle id `com.anlonely.AngelLiveTest` 和个人开发团队完成真机安装。
-- 个人开发团队不支持 iCloud / Push，本地 Debug 包改用空 entitlement 验证；修复前启动在 `CKContainer(identifier:)` 崩溃，修复后可稳定进入 App。
-- iPhone Mirroring 实时验证：欢迎页、收藏页、配置页、设置页可打开。
-- 输入订阅密钥 `444222000` 后弹出订阅内容列表，并成功安装 14 个官方插件。
-- 设备容器确认已安装插件包含 `chzzk`、`kick`、`soop`、`twitch`，订阅源持久化为 `https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/plugins.json`。
-- SOOP 首次进入分类时真机日志确认只拉取第 1、2、3 页房间列表，然后开始处理 19x 候选。
-- SOOP 19x 实时封面真机日志确认写入稳定 Kingfisher key：`https://liveimg.sooplive.com/m/{roomId}?320`，未再出现 `_al_preview` 时间戳缓存 key。
-- SOOP 播放控制真机复测：点击画面可弹出控制层，不再出现左键点击导致的持续闪烁和卡死。
-- SOOP 19x 筛选代码通过 iOS 26.1 真机 Debug 构建、安装和启动；本轮 iPhone Mirroring 被手机前台使用中断，未做最终截图确认。
-- Twitch 1.0.31 真机日志确认 `getCategories` / `getRooms` 均请求 `https://gql.twitch.tv/gql`，HTTP 200，并成功返回分类和直播间列表；未再出现 token server 的 `missing clientId/accessToken`。
-
-## 审查建议
-
-- 重点审查 `RoomPlaybackResolver.preferredInitialSelection` 是否符合 CHZZK 插件实际返回的 `playArgs` 结构。
-- 重点审查 `PlatformLoginCompatibility` 中 Twitch / Kick / SOOP 的 Cookie 名称和域名是否覆盖当前线上行为。
-- 重点审查 SOOP 兜底预览地址 `https://liveimg.sooplive.com/m/{roomId}` 在目标地区和网络环境下是否可访问。
-- 重点审查 iOS SOOP 19x 实时截图策略是否接受：只在内存缓存中替换稳定 `?320` key，App 重启后重新检测。
-- 重点审查 iOS SOOP 19x 筛选的产品语义：未知状态在检测完成前不进入 19x / 非19x结果，避免误显示。
-- 重点审查 Twitch 1.0.31 宿主侧兼容补丁的版本边界，确认后续上游插件修复后不会被覆盖。
-- 真机连接后建议验证 iOS 26.1 设备上的 WebKit 登录保存、播放器默认清晰度、SOOP 列表预览图和 SOOP 19x 播放控制四条主链路。
+- `LiveParsePluginCompatibilityPatch` 的 Twitch 版本边界是否足够保守。
+- `RoomPlaybackResolver.preferredInitialSelection` 是否符合 CHZZK 当前插件返回结构。
+- `PlatformCookieCollector` 的 Cookie 域匹配和 session Cookie 优先级。
+- SOOP 19x 筛选中“未知状态不进入 19x / 非19x结果”的产品语义。
+- SOOP 19x 实时封面只写内存缓存、不污染持久化字段的策略是否符合发布预期。

--- a/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
+++ b/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
@@ -33,6 +33,7 @@
 - 当 token server 返回缺少 `clientId/accessToken` 时，平台页会直接加载失败。
 - 新增 `LiveParsePluginCompatibilityPatch`，只对 `twitch@1.0.31` 注入兼容脚本。
 - 兼容脚本复用插件内已有的 `_tw_fetchTopGames`、`_tw_fetchAllStreamsPage`、`_tw_fetchCategoryStreamsPage`，把分类和直播间列表切回 `https://gql.twitch.tv/gql`。
+- 兼容 Twitch 分类 URL 的 slug，例如 `just-chatting` 会解析回游戏 ID `509658`，并按房间 `biz` 再做一次分类过滤。
 - 补丁按精确版本命中，后续上游插件升级到 1.0.32 或其它版本时自动停止注入。
 
 ### 3. CHZZK 默认清晰度
@@ -106,6 +107,7 @@
 - SOOP 封面 URL 标准化和空封面兜底。
 - CHZZK 类清晰度列表默认选择 1080p，跳过 Auto、空 URL 占位和 audio-only。
 - `twitch@1.0.31` 兼容脚本只命中该版本，并可在宿主 JavaScriptCore 中执行。
+- Twitch `just-chatting` slug 能解析到 `509658`，且只返回该分类房间。
 
 ## 兼容边界
 
@@ -131,7 +133,7 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device 
 
 结果：
 
-- Core 测试通过：`33 tests passed`。
+- Core 测试通过：`34 tests passed`。
 - iOS 26.1 真机 Debug 构建、安装、启动通过。
 - 个人开发签名无 iCloud entitlement 时可正常进入 App。
 - 输入订阅密钥 `444222000` 后可安装官方插件。

--- a/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
+++ b/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
@@ -12,6 +12,7 @@
 - SOOP 19x 直播间返回灰色年龄占位图，登录后仍缺少真实实时封面。
 - SOOP 需要列表筛选能力：全部 / 只显示 19x / 只显示非 19x。
 - iOS 真机 SOOP 19x 播放页左键点击不弹控制层、画面闪烁或卡死。
+- Twitch 1.0.31 点击平台后分类列表加载失败，报 `missing clientId or accessToken in token server response`。
 - iOS 真机个人开发签名缺少 iCloud entitlement 时启动闪退。
 - 官方订阅密钥 `444222000` 未解析，误走普通视频收藏。
 
@@ -23,6 +24,7 @@
 - 真机回归后补修：所有 CloudKit 入口在初始化 `CKContainer(identifier:)` 前先判断签名是否包含目标 iCloud 容器，避免个人开发证书无 iCloud 能力时启动或同步入口崩溃；订阅密钥服务补齐官方 `keys.json` 地址和 `444222000` 内置兜底。
 - SOOP 19x 复测后补修：只对 19x 占位封面做一次实时截图缓存，非 19x 房间不再 force refresh；首次进入 SOOP 拉取前三页并预热 19x 截图，滚动时继续按窗口预加载未处理过的 19x 房间。
 - SOOP 19x 筛选补修：iOS SOOP 分类页新增“全部 / 19x / 非19x”三段筛选；筛选结果基于同一套 19x 占位图检测状态，不改插件协议和持久化模型。
+- Twitch 1.0.31 补修：宿主加载插件后对该版本精确注入兼容脚本，把分类和房间列表从 Helix token server 路径切回插件已内置的 Twitch website GQL helper。
 
 ## 核心改动
 
@@ -84,6 +86,16 @@
 - 修复 `cookieInject` 写入 body 后又被 `envelope.body` 覆盖的问题。
 - 现在 body 注入结果会保留到最终请求。
 - 影响场景：插件需要把 Cookie 中的字段注入请求 body 时，之前会丢失。
+
+### 3.1. Twitch 1.0.31 列表加载修复
+
+新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift`：
+
+- 宿主在插件入口脚本执行并通过 `apiVersion` 检查后，按 manifest 精确版本注入兼容脚本。
+- 当前只命中 `twitch@1.0.31`，不会影响后续上游插件版本。
+- Twitch 1.0.31 发布说明写的是 website GQL，但导出的 `getCategories` / `getRooms` 仍调用 Helix token server；当 token server 返回缺少 `clientId/accessToken` 时，平台页直接失败。
+- 兼容脚本复用插件包内已存在的 `_tw_fetchTopGames`、`_tw_fetchAllStreamsPage`、`_tw_fetchCategoryStreamsPage`，让分类、全部直播和分类直播列表都走 `https://gql.twitch.tv/gql`。
+- 保留原插件分类缓存和房间去重 helper；若上游 helper 不存在才回退到原方法，便于问题定位。
 
 ### 4. SOOP 直播间预览图修复
 
@@ -212,12 +224,14 @@ iOS SOOP 19x 播放控制补充：
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift`
 - `docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md`
 
 ### Shared / Core 修改
 
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParseLoadedPlugin.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginManifest.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift`
 - `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginRegistry.swift`
@@ -290,6 +304,10 @@ iOS SOOP 19x 播放控制补充：
   - `refreshOnSelect` 的高画质项即使 URL 为空，仍允许作为初始候选。
 - `PlatformLoginCompatibilityTests`
   - manifest 显式声明 `auth.required=false` 时优先于宿主 fallback。
+- `PluginCompatibilityPatchTests`
+  - `twitch@1.0.31` 会生成 GQL 列表兼容脚本。
+  - `twitch@1.0.32` 等其它版本不被宿主覆盖。
+  - 兼容脚本可在宿主 `JSRuntime` / JavaScriptCore 中正常执行。
 
 ## 兼容性说明
 
@@ -300,6 +318,7 @@ iOS SOOP 19x 播放控制补充：
 - SOOP 19x 截图只作为 Kingfisher 内存缓存存在，App 重启后会重新按当前直播状态检测，不污染收藏、历史或 iCloud 数据。
 - UI 层保留原 `LiveModel.roomCover` / `userHeadImg` 字段，只新增展示用扩展，避免影响持久化模型结构。
 - 清晰度选择只改变初始默认项，用户手动切换清晰度流程未重写。
+- Twitch 列表兼容补丁只作用于 `twitch@1.0.31`，上游发布 1.0.32 或 manifest 版本变更后自动停止注入。
 
 ## 验证结果
 
@@ -316,7 +335,7 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device 
 结果：
 
 - `git diff --check` 通过。
-- Xcode 工具链直接运行 Core 测试通过：`30 tests passed`。
+- Xcode 工具链直接运行 Core 测试通过：`33 tests passed`。
 - iOS 26.1 真机 Debug 构建通过：`** BUILD SUCCEEDED **`。
 - iOS 26.1 真机安装和 console 启动通过。
 
@@ -332,6 +351,7 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device 
 - SOOP 19x 实时封面真机日志确认写入稳定 Kingfisher key：`https://liveimg.sooplive.com/m/{roomId}?320`，未再出现 `_al_preview` 时间戳缓存 key。
 - SOOP 播放控制真机复测：点击画面可弹出控制层，不再出现左键点击导致的持续闪烁和卡死。
 - SOOP 19x 筛选代码通过 iOS 26.1 真机 Debug 构建、安装和启动；本轮 iPhone Mirroring 被手机前台使用中断，未做最终截图确认。
+- Twitch 1.0.31 真机日志确认 `getCategories` / `getRooms` 均请求 `https://gql.twitch.tv/gql`，HTTP 200，并成功返回分类和直播间列表；未再出现 token server 的 `missing clientId/accessToken`。
 
 ## 审查建议
 
@@ -340,4 +360,5 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device 
 - 重点审查 SOOP 兜底预览地址 `https://liveimg.sooplive.com/m/{roomId}` 在目标地区和网络环境下是否可访问。
 - 重点审查 iOS SOOP 19x 实时截图策略是否接受：只在内存缓存中替换稳定 `?320` key，App 重启后重新检测。
 - 重点审查 iOS SOOP 19x 筛选的产品语义：未知状态在检测完成前不进入 19x / 非19x结果，避免误显示。
+- 重点审查 Twitch 1.0.31 宿主侧兼容补丁的版本边界，确认后续上游插件修复后不会被覆盖。
 - 真机连接后建议验证 iOS 26.1 设备上的 WebKit 登录保存、播放器默认清晰度、SOOP 列表预览图和 SOOP 19x 播放控制四条主链路。

--- a/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
+++ b/docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md
@@ -1,0 +1,343 @@
+# SimpleLiveTVOS 修复变更说明（ops4.7 审查版）
+
+日期：2026-05-16
+
+## 审查范围
+
+本次修改围绕 3 个用户可见问题：
+
+- Twitch / Kick Cookie 登录无法稳定保存或无法出现在登录入口。
+- CHZZK 默认播放清晰度被降到 Auto / 低清晰度。
+- SOOP Cookie 登录后部分直播间没有预览图。
+- SOOP 19x 直播间返回灰色年龄占位图，登录后仍缺少真实实时封面。
+- SOOP 需要列表筛选能力：全部 / 只显示 19x / 只显示非 19x。
+- iOS 真机 SOOP 19x 播放页左键点击不弹控制层、画面闪烁或卡死。
+- iOS 真机个人开发签名缺少 iCloud entitlement 时启动闪退。
+- 官方订阅密钥 `444222000` 未解析，误走普通视频收藏。
+
+同时修复代码审查发现的问题：
+
+- macOS 平台详情页登录入口把 `liveType` 当作 `pluginId` 传入，导致 SOOP 等平台登录页无法定位。
+- 初始清晰度选择可能选中空 URL 的“原画 / Best”占位项，导致播放器没有可播放地址。
+- ops4.7 复审后补修：音频轨不参与默认清晰度竞争、macOS Cookie 保存失败时登录状态置假、manifest 显式 `auth.required=false` 优先于宿主兜底、session Cookie 去重优先级、SOOP 兜底日志、tvOS 清晰度展示标题与 iOS/macOS 对齐。
+- 真机回归后补修：所有 CloudKit 入口在初始化 `CKContainer(identifier:)` 前先判断签名是否包含目标 iCloud 容器，避免个人开发证书无 iCloud 能力时启动或同步入口崩溃；订阅密钥服务补齐官方 `keys.json` 地址和 `444222000` 内置兜底。
+- SOOP 19x 复测后补修：只对 19x 占位封面做一次实时截图缓存，非 19x 房间不再 force refresh；首次进入 SOOP 拉取前三页并预热 19x 截图，滚动时继续按窗口预加载未处理过的 19x 房间。
+- SOOP 19x 筛选补修：iOS SOOP 分类页新增“全部 / 19x / 非19x”三段筛选；筛选结果基于同一套 19x 占位图检测状态，不改插件协议和持久化模型。
+
+## 核心改动
+
+### 1. 平台登录兼容修复
+
+新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift`：
+
+- 为旧版 manifest 缺少 `loginFlow` 的平台提供宿主侧兼容声明。
+- 覆盖平台：`twitch`、`kick`、`soop`。
+- Twitch 登录 URL：`https://www.twitch.tv/login`。
+- Kick 登录 URL：`https://kick.com/login`。
+- SOOP 登录 URL：`https://login.sooplive.com/afreeca/login.php`。
+- SOOP Cookie 域覆盖 `sooplive.co.kr`、`sooplive.com`、`afreecatv.com`。
+
+修改 `LiveParsePluginManifest.requiresLogin`：
+
+- 由原先只看 manifest 原始字段，改为走 `PlatformLoginCompatibility.requiresLogin`。
+- 旧插件即使没有声明登录字段，也可以进入账号管理和登录流程。
+
+修改 `PlatformLoginRegistry`：
+
+- 使用兼容层返回的 `loginFlow` 和 `auth`。
+- 登录入口列表可包含 Twitch / Kick / SOOP 旧 manifest。
+
+修复 `macOS/AngelLiveMacOS/Views/PlatformDetailView.swift`：
+
+- 平台详情页登录弹窗改为传 `viewModel.platform.pluginId`。
+- 避免 `soop` 平台被错误传成 `8` 后查不到登录入口。
+
+### 2. Cookie 收集与 Web 登录修复
+
+新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`：
+
+- 统一 iOS / macOS 的 Cookie 过滤、去重、签名和 UID 提取逻辑。
+- 支持同站兄弟域匹配，例如 `.twitch.tv` / `www.twitch.tv`、`kick.com` / `www.kick.com`。
+- Cookie header 去重时优先非空、当前 session、域名和 path 更具体的 Cookie，再比较长有效期。
+
+修改 iOS 登录面板 `PlatformLoginWebSheet.swift`：
+
+- 使用 `PlatformCookieCollector.filteredCookies` 收集相关域名 Cookie。
+- 使用 `PlatformCookieCollector.cookieHeader` 生成最终 Cookie 字符串。
+- 使用 `PlatformCookieCollector.containsAuthenticatedCookie` 判断是否已登录。
+- 重新登录 / 退出登录时清理相关域名的 Cookie 和 WebKit 站点数据。
+- 登录 WebView 默认使用移动 Safari 风格 UA，不再让旧 Twitch/Kick/SOOP 兜底流强制注入桌面 Chromium UA，避免 Twitch 把 WKWebView 判定成“不支持的浏览器”。
+- 开启 `javaScriptCanOpenWindowsAutomatically`，并用 `WKUIDelegate` 接管 `target=_blank` / `window.open`，让 SOOP 的 Apple / Google 第三方登录按钮在当前 WebView 内继续跳转。
+
+修改 macOS 登录面板 `MacPlatformLoginWebSheet.swift`：
+
+- 同步 iOS 的统一 Cookie 收集逻辑。
+- 打开登录页时立即轮询一次 Cookie，避免登录完成后等待下一轮定时器。
+- “重新登录”和“退出登录”会清理相关平台网页登录缓存，避免旧账号 Cookie 干扰。
+- Cookie 保存返回过期、无效或网络错误时显式把 `isLoggedIn` 置为 `false`，避免 UI 留在“账号信息”页。
+- 登录 WebView 默认使用桌面 Safari 风格 UA，并同步处理第三方登录新窗口，保持 iOS / macOS 登录行为一致。
+
+### 3. JSRuntime Cookie 注入修复
+
+修改 `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift`：
+
+- 修复 `cookieInject` 写入 body 后又被 `envelope.body` 覆盖的问题。
+- 现在 body 注入结果会保留到最终请求。
+- 影响场景：插件需要把 Cookie 中的字段注入请求 body 时，之前会丢失。
+
+### 4. SOOP 直播间预览图修复
+
+新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift`：
+
+- 统一标准化直播间封面和头像 URL。
+- 支持：
+  - 去掉 JSON 转义中的 `\/`。
+  - `//host/path` 补 `https:`。
+  - `host/path` 补 `https://`。
+  - SOOP 旧图床域 `liveimg.sooplive.co.kr` 统一到 `liveimg.sooplive.com`。
+  - SOOP 图床 `http` 自动升级为 `https`。
+- 当 SOOP 房间 `roomCover` 为空且 `roomId` 是数字时，兜底生成：
+  - `https://liveimg.sooplive.com/m/{roomId}?320`
+- 命中 SOOP 兜底时输出 `[ImageResolver][SOOP] fallback=...` 调试日志，便于真机回归判断是否命中。
+
+修改 `LiveParseJSPlatformManager.PluginRoomDTO.toLiveModel`：
+
+- 插件返回的 `roomCover` 和 `userHeadImg` 在进入 `LiveModel` 前先做标准化。
+
+新增 `LiveModel` 展示扩展：
+
+- `displayRoomCover`
+- `displayUserHeadImg`
+
+所有 UI 图片加载改用展示扩展，避免旧缓存或未标准化 URL 继续导致图片失败。
+
+iOS SOOP 19x 实时封面补充：
+
+- `PlatformDetailViewModel` 首次进入 SOOP 分类时预取前三页房间列表，避免 19x 房间只在滚动后才进入候选池。
+- SOOP `liveimg.sooplive.com/m/{roomId}` URL 统一稳定为 `?320`，不再给所有房间追加 `_al_preview` 时间戳。
+- 非 19x 房间只走普通 Kingfisher 缓存，不做实时截图、不做强制刷新。
+- 19x 判定通过封面 CDN 的 `HEAD/GET` 内容长度识别灰色年龄占位图；只有命中占位图的房间才会解析播放地址并截取首帧。
+- 生成的实时封面只写入 Kingfisher 内存缓存，key 为稳定的 `https://liveimg.sooplive.com/m/{roomId}?320`，不改写收藏和 CloudKit 持久化字段。
+- ViewModel 记录已检测和正在处理的 `roomId`，下拉刷新、点击刷新或重复进入同一列表不会对已处理房间二次拉流截图。
+- `RoomListViewController.willDisplay` 在滚动时把后续窗口交给 ViewModel，继续预加载新出现的 19x 房间。
+- 真机日志已确认 19x 写入稳定 key，例如 `https://liveimg.sooplive.com/m/294067533?320`、`https://liveimg.sooplive.com/m/294050349?320`。
+
+iOS SOOP 19x 筛选补充：
+
+- `SubCategoryViewController` 仅在 SOOP 平台显示三段筛选控件：`全部`、`19x`、`非19x`。
+- `PlatformDetailViewModel` 保留原始全量 `roomListCache`，新增按分类读取的 `filteredRoomList(...)`，避免筛选破坏分页和缓存。
+- 19x / 非19x 状态来自 `liveimg.sooplive.com/m/{roomId}?320` 的占位图检测；未知状态不会被放进 19x 或非19x筛选结果，检测完成后通过通知刷新列表。
+- 切换筛选时会立即触发当前分类首屏窗口的 19x 状态检测；滚动到列表后续位置时继续检测附近窗口。
+- 已检测过的 `roomId` 不会因为切换筛选、下拉刷新或点击刷新重复进入检测和拉流截图流程。
+
+iOS SOOP 19x 播放控制补充：
+
+- `UnifiedPlayerControlOverlay` 增加全屏透明 tap catcher，控制层隐藏时点击显示，显示时点击空白处隐藏。
+- `PlayerContainerView` 移除 VLC drawable 上的 SwiftUI `onTapGesture`，避免 VLCKit drawable 与 SwiftUI 同时争抢 19x 流点击事件。
+- `VLCVideoPlayerView` 在同一 media fingerprint 下不再从 `.paused` 强行恢复播放，只处理 `.stopped` / `.error` 恢复；销毁和 stop 时把 VLCKit stop/media 释放放到后台队列，减少主线程卡顿和闪退风险。
+
+### 5. CHZZK 默认清晰度修复
+
+修改 `Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift`：
+
+- 新增 `preferredInitialSelection(in:)`。
+- 默认播放不再盲目使用插件返回的第一个清晰度。
+- 清晰度评分规则：
+  - `audio` / `音频` 最低。
+  - `auto` / `自适应` 低于明确分辨率。
+  - `source` / `best` / `原画` 最高。
+  - `1080p`、`720p` 等按解析出的高度排序。
+  - 没有高度时回退 `qn`。
+- 只在可直接播放或声明 `refreshOnSelect` 的清晰度中比较。
+- 避免空 URL 的“原画 / Best”占位项抢占默认播放。
+- 音频轨不会参与初始默认清晰度竞争；如果没有任何视频候选，仍保持旧逻辑的首项兜底。
+
+修改 iOS / tvOS / macOS 的 `RoomInfoViewModel`：
+
+- 初次拿到 `playArgs` 后使用 `preferredInitialSelection`。
+- 手动切换清晰度仍保留原有路径。
+- tvOS 展示当前清晰度时改用 `qualityDisplayTitle(in:selection:)`，同名不同流类型时和 iOS / macOS 一样追加 HLS / FLV 区分。
+
+### 6. VLC fallback 构建兼容
+
+当前默认 KSPlayer 依赖链会解析 `https://github.com/TracyPlayer/FFmpegKit`，该远端在本次验证时不可用。为了能在 Xcode 26.5 上完成本地编译验证，使用仓库已有的 `USE_VLC=1` fallback 路径。
+
+补齐 fallback 与真实 KSPlayer 的最小接口差异：
+
+- `Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift`
+  - `KSOptions.playerTypes`
+  - `KSOptions.videoFilters`
+  - `KSOptions.audioFilters`
+  - `KSPlayerLayerBase.reset()`
+- `Shared/AngelLiveDependencies/Sources/PlayerOptions.swift`
+  - `init()` 显式标记 `override`，兼容 fallback 下 `KSOptions` 的公开初始化器。
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift`
+  - 增加 `isLocked` 状态，和真实播放器模型对齐。
+
+### 7. 真机签名兼容与订阅密钥修复
+
+新增 `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift`：
+
+- 在访问命名 CloudKit 容器前统一判断签名能力。
+- iOS / tvOS Debug 或 AdHoc 包通过 `embedded.mobileprovision` 读取 `com.apple.developer.icloud-container-identifiers`。
+- 如果当前签名没有 `iCloud.icloud.dev.igod.simplelive`，直接跳过对应 CloudKit 操作并输出日志。
+- App Store 包通常没有 `embedded.mobileprovision`，该路径仍信任正式签名 entitlement。
+
+接入该 guard 的 CloudKit 入口：
+
+- `FavoriteService`
+- `StreamBookmarkService`
+- `PluginSourceSyncService`
+- `PlatformCredentialSyncService`
+
+修复效果：
+
+- 个人开发团队不支持 iCloud / Push 的本地真机包可以正常启动。
+- 缺少 iCloud entitlement 时不再在 `CKContainer(identifier:)` 处触发 `EXC_BREAKPOINT / SIGTRAP`。
+- 本地收藏、插件安装、Cookie 登录仍可继续使用；仅跳过 iCloud 同步。
+
+修改 `PluginSourceKeyService`：
+
+- 补齐远程 `keys.json` 地址：
+  - `https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json`
+  - `https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/keys.json`
+- 增加官方密钥 `444222000` 的内置兜底映射。
+- 远程 keys 拉取失败时，`444222000` 仍会解析到官方插件索引，不会误当成普通视频地址。
+
+## 涉及文件
+
+### 新增文件
+
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift`
+- `docs/OPS4_7_REVIEW_CHANGES_2026-05-16.md`
+
+### Shared / Core 修改
+
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginManifest.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginRegistry.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/FavoriteService.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCredentialSyncService.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceKeyService.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PluginSourceSyncService.swift`
+- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/StreamBookmarkService.swift`
+- `Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift`
+
+### Shared / Dependencies 修改
+
+- `Shared/AngelLiveDependencies/Sources/KSPlayerFallback.swift`
+- `Shared/AngelLiveDependencies/Sources/PlayerOptions.swift`
+
+### iOS 修改
+
+- `iOS/AngelLive/AngelLive/FullUI/Components/LiveRoomCard.swift`
+- `iOS/AngelLive/AngelLive/Common/PlayerCore/VLCVideoPlayerView.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Managers/NowPlayingManager.swift`
+- `iOS/AngelLive/AngelLive/FullUI/ViewModels/PlatformDetailViewModel.swift`
+- `iOS/AngelLive/AngelLive/FullUI/ViewModels/RoomInfoViewModel.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/DetailPlayerView.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerContainerView.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/UnifiedPlayerControlOverlay.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/VerticalLiveControllerView.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoSheet.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoView.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/Setting/PlatformLoginWebSheet.swift`
+- `iOS/AngelLive/AngelLive/FullUI/Views/UIKit/ViewControllers/RoomListViewController.swift`
+
+### tvOS 修改
+
+- `TV/AngelLiveTVOS/Source/DetailPlayer/DetailPlayerView.swift`
+- `TV/AngelLiveTVOS/Source/DetailPlayer/PlayerControlCardView.swift`
+- `TV/AngelLiveTVOS/Source/DetailPlayer/RoomInfoViewModel.swift`
+- `TV/AngelLiveTVOS/Source/List/LiveCardView.swift`
+- `TV/TopShelfExtension/ContentProvider.swift`
+
+### macOS 修改
+
+- `macOS/AngelLiveMacOS/ViewModels/RoomInfoViewModel.swift`
+- `macOS/AngelLiveMacOS/Views/MacPlatformLoginWebSheet.swift`
+- `macOS/AngelLiveMacOS/Views/PlatformDetailView.swift`
+- `macOS/AngelLiveMacOS/Views/PlayerControlView.swift`
+
+## 新增测试覆盖
+
+修改 `Shared/AngelLiveCore/Tests/AngelLiveCoreTests/AngelLiveCoreTests.swift`：
+
+- `PlatformLoginCompatibilityTests`
+  - 旧 Twitch / Kick / SOOP manifest 能获得宿主登录兜底。
+  - manifest 自带 `loginFlow` 时优先使用 manifest，不被兜底覆盖。
+- `PluginSourceKeyTests`
+  - 官方短密钥 `444222000` 不依赖远程 keys 索引也能解析到官方插件索引。
+- `PlatformCookieCollectorTests`
+  - 兄弟域 Cookie 能正确过滤。
+  - 登录信号 Cookie 能被识别。
+  - Cookie header 能正确生成。
+  - 同名 Cookie 去重时 session Cookie 优先于旧 persistent Cookie。
+- `LiveImageURLResolverTests`
+  - SOOP 空封面生成预览 CDN URL。
+  - SOOP 旧图床域名 canonicalize。
+  - 非 SOOP 空封面保持为空。
+- `PlaybackInitialSelectionTests`
+  - CHZZK 类 Auto / 720p / 1080p 列表默认选 1080p。
+  - 空 URL 的“原画”占位项不会被默认选中。
+  - 有视频候选时跳过 audio-only 音频轨。
+  - `refreshOnSelect` 的高画质项即使 URL 为空，仍允许作为初始候选。
+- `PlatformLoginCompatibilityTests`
+  - manifest 显式声明 `auth.required=false` 时优先于宿主 fallback。
+
+## 兼容性说明
+
+- 兼容层是 data-only，后续插件 manifest 正式声明 `loginFlow` 后，会自动优先使用 manifest 字段。
+- SOOP 预览图兜底只在 `liveType` 为 `8` 或 `soop`，且 `roomId` 为纯数字时启用。
+- SOOP 19x 实时截图只在 iOS 列表层启用；非 19x 房间不会进入播放地址解析或截图流程。
+- SOOP 19x 筛选只在 iOS SOOP 分类页展示；其它平台和 tvOS/macOS 不显示该控件。
+- SOOP 19x 截图只作为 Kingfisher 内存缓存存在，App 重启后会重新按当前直播状态检测，不污染收藏、历史或 iCloud 数据。
+- UI 层保留原 `LiveModel.roomCover` / `userHeadImg` 字段，只新增展示用扩展，避免影响持久化模型结构。
+- 清晰度选择只改变初始默认项，用户手动切换清晰度流程未重写。
+
+## 验证结果
+
+已执行：
+
+```bash
+git diff --check
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Shared/AngelLiveCore
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer USE_VLC=1 xcodebuild build -workspace AngelLive.xcworkspace -scheme AngelLive -configuration Debug -destination 'platform=iOS,id=00008130-000204881E6A001C' -allowProvisioningUpdates -skipPackagePluginValidation
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device install app --device 6F726895-0F44-53B8-9291-C68C6C5B11A2 /Users/bing/Library/Developer/Xcode/DerivedData/AngelLive-gcijnxzpyclukqgalnuqneqbaqcp/Build/Products/Debug-iphoneos/AngelLive.app
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device process launch --device 6F726895-0F44-53B8-9291-C68C6C5B11A2 --terminate-existing --console com.anlonely.AngelLiveTest
+```
+
+结果：
+
+- `git diff --check` 通过。
+- Xcode 工具链直接运行 Core 测试通过：`30 tests passed`。
+- iOS 26.1 真机 Debug 构建通过：`** BUILD SUCCEEDED **`。
+- iOS 26.1 真机安装和 console 启动通过。
+
+真机状态：
+
+- Xcode 26.5 能识别已连接 iPhone 15 Pro，设备系统为 iOS 26.1，开发者模式已启用。
+- 使用本地测试 bundle id `com.anlonely.AngelLiveTest` 和个人开发团队完成真机安装。
+- 个人开发团队不支持 iCloud / Push，本地 Debug 包改用空 entitlement 验证；修复前启动在 `CKContainer(identifier:)` 崩溃，修复后可稳定进入 App。
+- iPhone Mirroring 实时验证：欢迎页、收藏页、配置页、设置页可打开。
+- 输入订阅密钥 `444222000` 后弹出订阅内容列表，并成功安装 14 个官方插件。
+- 设备容器确认已安装插件包含 `chzzk`、`kick`、`soop`、`twitch`，订阅源持久化为 `https://ghfast.top/https://raw.githubusercontent.com/pcccccc/LiveParse/main/Dist/PluginRelease/plugins.json`。
+- SOOP 首次进入分类时真机日志确认只拉取第 1、2、3 页房间列表，然后开始处理 19x 候选。
+- SOOP 19x 实时封面真机日志确认写入稳定 Kingfisher key：`https://liveimg.sooplive.com/m/{roomId}?320`，未再出现 `_al_preview` 时间戳缓存 key。
+- SOOP 播放控制真机复测：点击画面可弹出控制层，不再出现左键点击导致的持续闪烁和卡死。
+- SOOP 19x 筛选代码通过 iOS 26.1 真机 Debug 构建、安装和启动；本轮 iPhone Mirroring 被手机前台使用中断，未做最终截图确认。
+
+## 审查建议
+
+- 重点审查 `RoomPlaybackResolver.preferredInitialSelection` 是否符合 CHZZK 插件实际返回的 `playArgs` 结构。
+- 重点审查 `PlatformLoginCompatibility` 中 Twitch / Kick / SOOP 的 Cookie 名称和域名是否覆盖当前线上行为。
+- 重点审查 SOOP 兜底预览地址 `https://liveimg.sooplive.com/m/{roomId}` 在目标地区和网络环境下是否可访问。
+- 重点审查 iOS SOOP 19x 实时截图策略是否接受：只在内存缓存中替换稳定 `?320` key，App 重启后重新检测。
+- 重点审查 iOS SOOP 19x 筛选的产品语义：未知状态在检测完成前不进入 19x / 非19x结果，避免误显示。
+- 真机连接后建议验证 iOS 26.1 设备上的 WebKit 登录保存、播放器默认清晰度、SOOP 列表预览图和 SOOP 19x 播放控制四条主链路。

--- a/iOS/AngelLive/AngelLive/Common/PlayerCore/VLCVideoPlayerView.swift
+++ b/iOS/AngelLive/AngelLive/Common/PlayerCore/VLCVideoPlayerView.swift
@@ -161,9 +161,8 @@ struct VLCVideoPlayerView: UIViewRepresentable {
 
         deinit {
             Logger.debug("[VLCBridge][\(traceID)] coordinator deinit", category: .player)
-            mediaPlayer.stop()
             mediaPlayer.drawable = nil
-            mediaPlayer.media = nil
+            stopPlayerOffMain(releaseMedia: true)
             notificationTokens.forEach(NotificationCenter.default.removeObserver)
         }
 
@@ -206,13 +205,15 @@ struct VLCVideoPlayerView: UIViewRepresentable {
                 return
             }
 
-            // Avoid repeatedly calling play() while opening/buffering, which can reset the stream.
+            // Avoid repeatedly calling play() during SwiftUI updates. User
+            // taps, state callbacks, and overlay changes all rebuild this
+            // representable; only a new media fingerprint should force play.
             switch mediaPlayer.state {
-            case .paused, .stopped, .stopping, .error:
+            case .stopped, .error:
                 notifyState(.buffering)
-                Logger.debug("[VLCBridge][\(traceID)] resume play from \(describe(mediaPlayer.state))", category: .player)
+                Logger.debug("[VLCBridge][\(traceID)] recover play from \(describe(mediaPlayer.state))", category: .player)
                 mediaPlayer.play()
-            case .opening, .buffering, .playing:
+            case .paused, .stopping, .opening, .buffering, .playing:
                 break
             @unknown default:
                 Logger.warning("[VLCBridge][\(traceID)] unknown player state in playIfNeeded", category: .player)
@@ -323,9 +324,9 @@ struct VLCVideoPlayerView: UIViewRepresentable {
                 guard let self else { return }
                 Logger.debug("[VLCBridge][\(traceID)] handler stop()", category: .player)
                 shouldResumeAfterForeground = false
-                mediaPlayer.stop()
-                mediaPlayer.media = nil
+                mediaPlayer.drawable = nil
                 currentRequestFingerprint = nil
+                stopPlayerOffMain(releaseMedia: true)
                 notifyState(.stopped)
             }
             controller?.enterBackgroundHandler = { [weak self] in
@@ -358,6 +359,19 @@ struct VLCVideoPlayerView: UIViewRepresentable {
             DispatchQueue.main.async { [weak self] in
                 self?.controller?.updateState(state)
                 self?.onStateChanged?(state)
+            }
+        }
+
+        private func stopPlayerOffMain(releaseMedia: Bool) {
+            let player = mediaPlayer
+            let traceID = traceID
+            DispatchQueue.global(qos: .userInitiated).async {
+                Logger.debug("[VLCBridge][\(traceID)] async stop begin", category: .player)
+                player.stop()
+                if releaseMedia {
+                    player.media = nil
+                }
+                Logger.debug("[VLCBridge][\(traceID)] async stop end", category: .player)
             }
         }
 

--- a/iOS/AngelLive/AngelLive/FullUI/Components/LiveRoomCard.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Components/LiveRoomCard.swift
@@ -74,12 +74,12 @@ struct LiveRoomCard: View {
     }
 
     private var coverURL: URL? {
-        guard !room.roomCover.isEmpty, let url = URL(string: room.roomCover) else { return nil }
+        guard !room.displayRoomCover.isEmpty, let url = URL(string: room.displayRoomCover) else { return nil }
         return url
     }
 
     private var avatarURL: URL? {
-        guard !room.userHeadImg.isEmpty, let url = URL(string: room.userHeadImg) else { return nil }
+        guard !room.displayUserHeadImg.isEmpty, let url = URL(string: room.displayUserHeadImg) else { return nil }
         return url
     }
 

--- a/iOS/AngelLive/AngelLive/FullUI/Managers/NowPlayingManager.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Managers/NowPlayingManager.swift
@@ -34,7 +34,7 @@ enum NowPlayingManager {
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
 
         // 异步加载封面图
-        loadArtwork(from: room.roomCover) { artwork in
+        loadArtwork(from: room.displayRoomCover) { artwork in
             if let artwork {
                 MPNowPlayingInfoCenter.default().nowPlayingInfo?[MPMediaItemPropertyArtwork] = artwork
             }

--- a/iOS/AngelLive/AngelLive/FullUI/ViewModels/PlatformDetailViewModel.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/ViewModels/PlatformDetailViewModel.swift
@@ -8,9 +8,35 @@
 import Foundation
 import SwiftUI
 import Observation
+internal import AVFoundation
+internal import CoreImage
+internal import QuartzCore
+import UIKit
 import AngelLiveCore
 import AngelLiveDependencies
 import Alamofire
+
+enum SOOPAdultRoomFilter: Int, CaseIterable {
+    case all
+    case adultOnly
+    case nonAdultOnly
+
+    var title: String {
+        switch self {
+        case .all:
+            return "全部"
+        case .adultOnly:
+            return "19x"
+        case .nonAdultOnly:
+            return "非19x"
+        }
+    }
+}
+
+private enum SOOPAdultRoomState {
+    case adult
+    case nonAdult
+}
 
 @Observable
 class PlatformDetailViewModel {
@@ -67,6 +93,14 @@ class PlatformDetailViewModel {
     private let pageSize = 20
     var hasMoreRooms = true
 
+    private let soopInitialPreviewPageCount = 3
+    private let soopScrollPreviewWindowSize = 48
+    var soopAdultRoomFilter: SOOPAdultRoomFilter = .all
+    @ObservationIgnored private var soopAdultRoomStates: [String: SOOPAdultRoomState] = [:]
+    @ObservationIgnored private var soopPreviewCheckedRoomIDs: Set<String> = []
+    @ObservationIgnored private var soopPreviewInFlightRoomIDs: Set<String> = []
+    @ObservationIgnored private var previewSnapshotTasks: [String: Task<Void, Never>] = [:]
+
     init(platform: Platformdescription) {
         self.platform = platform
     }
@@ -117,22 +151,39 @@ class PlatformDetailViewModel {
             // 获取 parentBiz (对于 YY 平台可能需要)
             let parentBiz = currentMainCategory?.biz
 
-            let fetchedRooms = try await LiveService.fetchRoomList(
-                liveType: platform.liveType,
-                category: subCategory,
-                parentBiz: parentBiz,
-                page: currentPage
-            )
+            let fetchedRooms: [LiveModel]
+            if refresh && isSOOPPlatform {
+                let result = try await fetchInitialSOOPRoomPages(
+                    category: subCategory,
+                    parentBiz: parentBiz
+                )
+                fetchedRooms = result.rooms
+                currentPage = result.lastLoadedPage
+                hasMoreRooms = result.hasMore
+            } else {
+                fetchedRooms = try await LiveService.fetchRoomList(
+                    liveType: platform.liveType,
+                    category: subCategory,
+                    parentBiz: parentBiz,
+                    page: currentPage
+                )
 
-            if fetchedRooms.isEmpty {
-                hasMoreRooms = false
+                if fetchedRooms.isEmpty {
+                    hasMoreRooms = false
+                }
             }
+
+            let roomsWithPreview = roomsByNormalizingSOOPPreviewURLs(fetchedRooms)
 
             if refresh {
-                roomList = fetchedRooms.removingDuplicates()
+                roomList = roomsWithPreview.removingDuplicates()
             } else {
-                roomList = roomList.appendingUnique(contentsOf: fetchedRooms)
+                roomList = roomList.appendingUnique(contentsOf: roomsWithPreview)
             }
+            warmSOOPAdultPreviewSnapshots(
+                for: refresh ? roomList : roomsWithPreview,
+                cacheKey: cacheKey
+            )
             // 清除错误状态（加载成功）
             roomError = nil
         } catch {
@@ -182,5 +233,486 @@ class PlatformDetailViewModel {
         if roomList.isEmpty {
             await loadRoomList()
         }
+    }
+
+    private var isSOOPPlatform: Bool {
+        let pluginId = platform.pluginId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let rawLiveType = platform.liveType.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return pluginId == "soop" || rawLiveType == "8" || rawLiveType == "soop"
+    }
+
+    var supportsSOOPAdultRoomFilter: Bool {
+        isSOOPPlatform
+    }
+
+    @MainActor
+    func setSOOPAdultRoomFilter(_ filter: SOOPAdultRoomFilter) {
+        guard supportsSOOPAdultRoomFilter, soopAdultRoomFilter != filter else { return }
+        soopAdultRoomFilter = filter
+        NotificationCenter.default.post(name: .soopAdultRoomFilterDidUpdate, object: self)
+    }
+
+    @MainActor
+    func filteredRoomList(mainCategoryIndex: Int, subCategoryIndex: Int) -> [LiveModel] {
+        let rooms = roomListCache["\(mainCategoryIndex)-\(subCategoryIndex)"] ?? []
+        guard supportsSOOPAdultRoomFilter else { return rooms }
+
+        switch soopAdultRoomFilter {
+        case .all:
+            return rooms
+        case .adultOnly:
+            return rooms.filter { soopAdultRoomState(for: $0) == .adult }
+        case .nonAdultOnly:
+            return rooms.filter { soopAdultRoomState(for: $0) == .nonAdult }
+        }
+    }
+
+    @MainActor
+    func preloadSOOPAdultPreviewSnapshots(
+        around room: LiveModel,
+        mainCategoryIndex: Int,
+        subCategoryIndex: Int
+    ) {
+        guard isSOOPPlatform else { return }
+        let key = "\(mainCategoryIndex)-\(subCategoryIndex)"
+        let cachedRooms = roomListCache[key] ?? []
+        let rawIndex = cachedRooms.firstIndex { cachedRoom in
+            cachedRoom.id == room.id
+                || (!room.roomId.isEmpty && cachedRoom.roomId == room.roomId)
+        }
+        guard let rawIndex else { return }
+
+        let endIndex = min(cachedRooms.count, rawIndex + soopScrollPreviewWindowSize)
+        let rooms = Array(cachedRooms[rawIndex..<endIndex])
+        warmSOOPAdultPreviewSnapshots(for: rooms, cacheKey: key)
+    }
+
+    @MainActor
+    func preloadInitialSOOPAdultPreviewSnapshots(
+        mainCategoryIndex: Int,
+        subCategoryIndex: Int
+    ) {
+        guard isSOOPPlatform else { return }
+        let key = "\(mainCategoryIndex)-\(subCategoryIndex)"
+        let cachedRooms = roomListCache[key] ?? []
+        let rooms = Array(cachedRooms.prefix(soopScrollPreviewWindowSize))
+        warmSOOPAdultPreviewSnapshots(for: rooms, cacheKey: key)
+    }
+
+    private func fetchInitialSOOPRoomPages(
+        category: LiveCategoryModel,
+        parentBiz: String?
+    ) async throws -> (rooms: [LiveModel], lastLoadedPage: Int, hasMore: Bool) {
+        var combinedRooms: [LiveModel] = []
+        var lastLoadedPage = 1
+        var hasMore = true
+
+        for page in 1...soopInitialPreviewPageCount {
+            do {
+                let rooms = try await LiveService.fetchRoomList(
+                    liveType: platform.liveType,
+                    category: category,
+                    parentBiz: parentBiz,
+                    page: page
+                )
+                if rooms.isEmpty {
+                    hasMore = false
+                    break
+                }
+
+                combinedRooms.append(contentsOf: rooms)
+                lastLoadedPage = page
+            } catch {
+                if page == 1 {
+                    throw error
+                }
+                Logger.warning("[SOOPPreview] warm page \(page) failed: \(error.localizedDescription)", category: .general)
+                break
+            }
+        }
+
+        return (combinedRooms, lastLoadedPage, hasMore)
+    }
+
+    @MainActor
+    private func warmSOOPAdultPreviewSnapshots(for rooms: [LiveModel], cacheKey: String) {
+        guard isSOOPPlatform else { return }
+        var pendingRooms: [LiveModel] = []
+        var pendingRoomIDs = Set<String>()
+
+        for room in rooms {
+            guard let roomID = soopPreviewRoomID(for: room),
+                  !soopPreviewCheckedRoomIDs.contains(roomID),
+                  !soopPreviewInFlightRoomIDs.contains(roomID) else {
+                continue
+            }
+            soopPreviewInFlightRoomIDs.insert(roomID)
+            pendingRoomIDs.insert(roomID)
+            pendingRooms.append(room)
+        }
+        guard !pendingRooms.isEmpty else { return }
+
+        let taskID = UUID().uuidString
+        let task = Task { [weak self, pendingRoomIDs] in
+            let probeResult = await SOOPPreviewSnapshotService.adultPlaceholderCandidates(in: pendingRooms)
+            await MainActor.run {
+                guard let self else { return }
+                self.applySOOPAdultProbeResult(probeResult, cacheKey: cacheKey)
+            }
+
+            let refreshedCount = await SOOPPreviewSnapshotService.refreshAdultPreviewSnapshots(
+                candidates: probeResult.candidates,
+                cacheKey: cacheKey
+            )
+            Logger.debug(
+                "[SOOPPreview] snapshot candidates=\(probeResult.candidates.count) refreshed=\(refreshedCount) checked=\(probeResult.checkedRoomIDs.count)",
+                category: .general
+            )
+
+            await MainActor.run {
+                guard let self else { return }
+                self.previewSnapshotTasks[taskID] = nil
+                self.soopPreviewInFlightRoomIDs.subtract(pendingRoomIDs)
+            }
+        }
+        previewSnapshotTasks[taskID] = task
+    }
+
+    @MainActor
+    private func applySOOPAdultProbeResult(
+        _ result: SOOPPreviewSnapshotService.PlaceholderProbeResult,
+        cacheKey: String
+    ) {
+        for roomID in result.adultRoomIDs {
+            soopAdultRoomStates[roomID] = .adult
+        }
+        for roomID in result.nonAdultRoomIDs {
+            soopAdultRoomStates[roomID] = .nonAdult
+        }
+        soopPreviewCheckedRoomIDs.formUnion(result.checkedRoomIDs)
+        soopPreviewInFlightRoomIDs.subtract(result.nonAdultRoomIDs)
+        NotificationCenter.default.post(
+            name: .soopAdultRoomFilterDidUpdate,
+            object: self,
+            userInfo: ["cacheKey": cacheKey]
+        )
+    }
+
+    private func roomsByNormalizingSOOPPreviewURLs(_ rooms: [LiveModel]) -> [LiveModel] {
+        guard isSOOPPlatform else { return rooms }
+
+        return rooms.map { room in
+            guard let previewURL = LiveImageURLResolver.soopLivePreviewURLString(
+                roomId: room.roomId
+            ), shouldUseStableSOOPPreviewURL(for: room) else {
+                return room
+            }
+
+            var normalized = LiveModel(
+                userName: room.userName,
+                roomTitle: room.roomTitle,
+                roomCover: previewURL,
+                userHeadImg: room.userHeadImg,
+                liveType: room.liveType,
+                liveState: room.liveState,
+                userId: room.userId,
+                roomId: room.roomId,
+                liveWatchedCount: room.liveWatchedCount
+            )
+            normalized.id = room.id
+            return normalized
+        }
+    }
+
+    private func shouldUseStableSOOPPreviewURL(for room: LiveModel) -> Bool {
+        let rawCover = room.roomCover.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawCover.isEmpty else { return true }
+
+        let normalized = LiveImageURLResolver.normalizedURLString(rawCover)
+        guard let url = URL(string: normalized) else { return false }
+        return SOOPPreviewSnapshotService.isSOOPLivePreviewURL(url)
+    }
+
+    private func soopAdultRoomState(for room: LiveModel) -> SOOPAdultRoomState? {
+        guard let roomID = soopPreviewRoomID(for: room) else { return nil }
+        return soopAdultRoomStates[roomID]
+    }
+}
+
+extension Notification.Name {
+    static let soopPreviewSnapshotDidUpdate = Notification.Name("SOOPPreviewSnapshotDidUpdate")
+    static let soopAdultRoomFilterDidUpdate = Notification.Name("SOOPAdultRoomFilterDidUpdate")
+}
+
+private func soopPreviewRoomID(for room: LiveModel) -> String? {
+    let roomID = room.roomId.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !roomID.isEmpty, roomID.allSatisfy(\.isNumber) else { return nil }
+    return roomID
+}
+
+private enum SOOPPreviewSnapshotService {
+    private static let adultPlaceholderContentLengthLimit = 12_000
+    private static let detectionBatchSize = 16
+    private static let playbackSnapshotUserAgent = "libmpv"
+
+    struct PlaceholderProbeResult: Sendable {
+        let candidates: [SnapshotCandidate]
+        let adultRoomIDs: Set<String>
+        let nonAdultRoomIDs: Set<String>
+        let checkedRoomIDs: Set<String>
+    }
+
+    struct SnapshotCandidate: Sendable {
+        let roomID: String
+        let room: LiveModel
+        let coverURL: URL
+    }
+
+    private struct PlaceholderProbe: Sendable {
+        let roomIndex: Int
+        let roomID: String
+        let candidate: SnapshotCandidate?
+    }
+
+    static func refreshAdultPreviewSnapshots(
+        candidates: [SnapshotCandidate],
+        cacheKey: String
+    ) async -> Int {
+        var refreshedCount = 0
+        for candidate in candidates {
+            guard !Task.isCancelled else {
+                return refreshedCount
+            }
+            guard let image = await playbackSnapshot(for: candidate.room) else {
+                Logger.debug("[SOOPPreview] snapshot image unavailable roomId=\(candidate.room.roomId)", category: .general)
+                continue
+            }
+            storeSnapshot(image, for: candidate.coverURL, cacheKey: cacheKey)
+            refreshedCount += 1
+        }
+        return refreshedCount
+    }
+
+    static func adultPlaceholderCandidates(
+        in rooms: [LiveModel]
+    ) async -> PlaceholderProbeResult {
+        var candidates: [SnapshotCandidate] = []
+        var adultRoomIDs = Set<String>()
+        var nonAdultRoomIDs = Set<String>()
+        var checkedRoomIDs = Set<String>()
+        let scanRooms = Array(rooms)
+        var startIndex = 0
+
+        while startIndex < scanRooms.count {
+            guard !Task.isCancelled else {
+                return PlaceholderProbeResult(
+                    candidates: candidates,
+                    adultRoomIDs: adultRoomIDs,
+                    nonAdultRoomIDs: nonAdultRoomIDs,
+                    checkedRoomIDs: checkedRoomIDs
+                )
+            }
+            let endIndex = min(startIndex + detectionBatchSize, scanRooms.count)
+            let batch = Array(scanRooms[startIndex..<endIndex])
+
+            await withTaskGroup(of: PlaceholderProbe?.self) { group in
+                for (offset, room) in batch.enumerated() {
+                    guard let roomID = soopPreviewRoomID(for: room),
+                          let coverURL = URL(string: room.displayRoomCover),
+                          isSOOPLivePreviewURL(coverURL) else { continue }
+                    let roomIndex = startIndex + offset
+                    group.addTask {
+                        guard let isPlaceholder = await adultPlaceholderState(at: coverURL) else { return nil }
+                        return PlaceholderProbe(
+                            roomIndex: roomIndex,
+                            roomID: roomID,
+                            candidate: isPlaceholder
+                                ? SnapshotCandidate(roomID: roomID, room: room, coverURL: coverURL)
+                                : nil
+                        )
+                    }
+                }
+
+                var batchProbes: [PlaceholderProbe] = []
+                for await result in group {
+                    if let result {
+                        batchProbes.append(result)
+                    }
+                }
+                for probe in batchProbes {
+                    checkedRoomIDs.insert(probe.roomID)
+                    if probe.candidate == nil {
+                        nonAdultRoomIDs.insert(probe.roomID)
+                    }
+                }
+                let batchCandidates = batchProbes
+                    .compactMap { probe -> (Int, SnapshotCandidate)? in
+                        guard let candidate = probe.candidate else { return nil }
+                        return (probe.roomIndex, candidate)
+                    }
+                    .sorted { $0.0 < $1.0 }
+                    .map(\.1)
+
+                adultRoomIDs.formUnion(batchCandidates.map(\.roomID))
+                candidates.append(contentsOf: batchCandidates)
+            }
+
+            startIndex = endIndex
+        }
+
+        if candidates.isEmpty {
+            Logger.debug(
+                "[SOOPPreview] snapshot candidates=0 checked=\(checkedRoomIDs.count)",
+                category: .general
+            )
+        }
+
+        return PlaceholderProbeResult(
+            candidates: candidates,
+            adultRoomIDs: adultRoomIDs,
+            nonAdultRoomIDs: nonAdultRoomIDs,
+            checkedRoomIDs: checkedRoomIDs
+        )
+    }
+
+    static func isSOOPLivePreviewURL(_ url: URL) -> Bool {
+        url.host?.lowercased() == "liveimg.sooplive.com"
+            && url.path.hasPrefix("/m/")
+    }
+
+    private static func adultPlaceholderState(at url: URL) async -> Bool? {
+        var request = URLRequest(url: url)
+        request.httpMethod = "HEAD"
+        request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse,
+               !(200..<300).contains(http.statusCode) {
+                return nil
+            }
+
+            if let lengthText = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Length"),
+               let length = Int(lengthText),
+               length > 0 {
+                return length <= adultPlaceholderContentLengthLimit
+            }
+
+            let expectedLength = response.expectedContentLength
+            if expectedLength > 0 {
+                return expectedLength <= adultPlaceholderContentLengthLimit
+            }
+        } catch {
+            Logger.debug("[SOOPPreview] placeholder HEAD failed: \(error.localizedDescription)", category: .general)
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            if let http = response as? HTTPURLResponse,
+               !(200..<300).contains(http.statusCode) {
+                return nil
+            }
+            return data.count <= adultPlaceholderContentLengthLimit
+        } catch {
+            Logger.debug("[SOOPPreview] placeholder GET failed: \(error.localizedDescription)", category: .general)
+            return nil
+        }
+    }
+
+    private static func playbackSnapshot(for room: LiveModel) async -> UIImage? {
+        do {
+            guard let platform = SandboxPluginCatalog.platform(for: room.liveType) else { return nil }
+            let playArgs = try await LiveParseJSPlatformManager.getPlayArgs(
+                platform: platform,
+                roomId: room.roomId,
+                userId: room.userId
+            )
+            guard let selected = RoomPlaybackResolver.firstSelection(
+                in: playArgs,
+                where: RoomPlaybackResolver.isHLSQuality
+            ) ?? RoomPlaybackResolver.preferredInitialSelection(in: playArgs),
+                  playArgs.indices.contains(selected.cdnIndex) else {
+                return nil
+            }
+
+            let cdn = playArgs[selected.cdnIndex]
+            let preparedQuality = try await RoomPlaybackPreparer.prepare(
+                roomId: room.roomId,
+                cdn: cdn,
+                quality: selected.quality,
+                plugin: platform
+            )
+            guard let url = RoomPlaybackResolver.playableURL(for: preparedQuality) else { return nil }
+            let requestOptions = RoomPlaybackResolver.requestOptions(
+                for: preparedQuality,
+                fallbackUserAgent: playbackSnapshotUserAgent
+            )
+            return await firstFrameImage(from: url, headers: requestOptions.headers)
+        } catch {
+            Logger.debug(
+                "[SOOPPreview] snapshot failed roomId=\(room.roomId): \(error.localizedDescription)",
+                category: .general
+            )
+            return nil
+        }
+    }
+
+    private static func firstFrameImage(from url: URL, headers: [String: String]) async -> UIImage? {
+        await Task.detached(priority: .utility) {
+            var options: [String: Any] = [:]
+            if !headers.isEmpty {
+                options["AVURLAssetHTTPHeaderFieldsKey"] = headers
+            }
+
+            let asset = AVURLAsset(url: url, options: options)
+            let playerItem = AVPlayerItem(asset: asset)
+            let videoOutput = AVPlayerItemVideoOutput(pixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA)
+            ])
+            playerItem.add(videoOutput)
+
+            let player = AVPlayer(playerItem: playerItem)
+            player.isMuted = true
+            player.automaticallyWaitsToMinimizeStalling = true
+            let imageContext = CIContext()
+            defer {
+                player.pause()
+                playerItem.remove(videoOutput)
+            }
+
+            player.play()
+            let deadline = Date().addingTimeInterval(7)
+            while Date() < deadline {
+                guard !Task.isCancelled else { return nil }
+                try? await Task.sleep(nanoseconds: 150_000_000)
+
+                let itemTime = videoOutput.itemTime(forHostTime: CACurrentMediaTime())
+                guard videoOutput.hasNewPixelBuffer(forItemTime: itemTime),
+                      let pixelBuffer = videoOutput.copyPixelBuffer(forItemTime: itemTime, itemTimeForDisplay: nil) else {
+                    continue
+                }
+
+                let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+                if let cgImage = imageContext.createCGImage(ciImage, from: ciImage.extent) {
+                    return UIImage(cgImage: cgImage)
+                }
+            }
+
+            return nil
+        }.value
+    }
+
+    @MainActor
+    private static func storeSnapshot(_ image: UIImage, for url: URL, cacheKey: String) {
+        // Keep the model as a normal remote SOOP preview URL. We only replace
+        // Kingfisher's in-memory image for that stable URL, so favorites/cloud
+        // persistence never receives a generated local file path.
+        ImageCache.default.store(image, forKey: url.absoluteString, toDisk: false)
+        Logger.debug("[SOOPPreview] snapshot stored key=\(url.absoluteString)", category: .general)
+        NotificationCenter.default.post(
+            name: .soopPreviewSnapshotDidUpdate,
+            object: nil,
+            userInfo: ["cacheKey": cacheKey]
+        )
     }
 }

--- a/iOS/AngelLive/AngelLive/FullUI/ViewModels/RoomInfoViewModel.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/ViewModels/RoomInfoViewModel.swift
@@ -134,7 +134,11 @@ final class RoomInfoViewModel {
             self.playErrorMessage = "暂无可用的播放源"
             return
         }
-        self.changePlayUrl(cdnIndex: 0, urlIndex: 0)
+        let initialSelection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        self.changePlayUrl(
+            cdnIndex: initialSelection?.cdnIndex ?? 0,
+            urlIndex: initialSelection?.qualityIndex ?? 0
+        )
 
         // 已成功获取到播放参数，标记已加载
         hasLoadedPlayURL = true

--- a/iOS/AngelLive/AngelLive/FullUI/Views/DetailPlayerView.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/DetailPlayerView.swift
@@ -342,7 +342,7 @@ struct DetailPlayerView: View {
     // MARK: - Background
 
     private var backgroundView: some View {
-        BlurredBackgroundView(imageURL: viewModel.currentRoom.userHeadImg)
+        BlurredBackgroundView(imageURL: viewModel.currentRoom.displayUserHeadImg)
             .edgesIgnoringSafeArea(.all)
     }
 

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerContainerView.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerContainerView.swift
@@ -400,7 +400,7 @@ struct PlayerContentView: View {
                     }
                 } else {
                     // 封面图作为背景
-                    KFImage(URL(string: viewModel.currentRoom.roomCover))
+                    KFImage(URL(string: viewModel.currentRoom.displayRoomCover))
                         .placeholder {
                             Rectangle()
                                 .fill(AppConstants.Colors.placeholderGradient())
@@ -464,11 +464,9 @@ struct PlayerContentView: View {
             hasVLCStartedPlayback = false
             vlcState = .stopped
         }
-        // VLC 模式下的单击手势，切换控制层显示/隐藏
-        .contentShape(Rectangle())
-        .onTapGesture {
-            vlcMaskShow.toggle()
-        }
+        // Tap handling belongs to the SwiftUI overlay. If the VLC drawable
+        // also owns taps, SOOP 19+ streams can flicker while the overlay never
+        // receives the first left click.
         .frame(maxWidth: .infinity, maxHeight: isVerticalLiveMode ? .infinity : nil)
         .clipped()
     }

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/KSVideoPlayerModelFallback.swift
@@ -10,6 +10,7 @@ public final class KSVideoPlayerModel: ObservableObject {
     public var config: KSVideoPlayer.Coordinator
     public var options: KSOptions
     @Published public var url: URL?
+    @Published var isLocked = false
 
     public init(title: String, config: KSVideoPlayer.Coordinator, options: KSOptions, url: URL? = nil) {
         self.title = title

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/VerticalLiveControllerView.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/PlayerUI/VerticalLiveControllerView.swift
@@ -114,7 +114,7 @@ struct VerticalLiveControllerView: View {
                     Button {
                         showStreamerInfo = true
                     } label: {
-                        KFAnimatedImage(URL(string: viewModel.currentRoom.userHeadImg))
+                        KFAnimatedImage(URL(string: viewModel.currentRoom.displayUserHeadImg))
                             .configure { view in
                                 view.framePreloadCount = 2
                             }

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoSheet.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoSheet.swift
@@ -56,7 +56,7 @@ struct StreamerInfoSheet: View {
     private var headerSection: some View {
         VStack(spacing: 12) {
             // 主播头像
-            if let avatarURL = URL(string: room.userHeadImg), !room.userHeadImg.isEmpty {
+            if let avatarURL = URL(string: room.displayUserHeadImg), !room.displayUserHeadImg.isEmpty {
                 KFAnimatedImage(avatarURL)
                     .configure { view in
                         view.framePreloadCount = 2

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoView.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/StreamerInfoView.swift
@@ -76,7 +76,7 @@ struct StreamerInfoView: View {
                 Button {
                     showStreamerInfo = true
                 } label: {
-                    KFAnimatedImage(URL(string: viewModel.currentRoom.userHeadImg))
+                    KFAnimatedImage(URL(string: viewModel.currentRoom.displayUserHeadImg))
                         .configure { view in
                             view.framePreloadCount = 2
                         }

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Player/UnifiedPlayerControlOverlay.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Player/UnifiedPlayerControlOverlay.swift
@@ -145,6 +145,8 @@ struct UnifiedPlayerControlOverlay: View {
 
     var body: some View {
         ZStack {
+            playerTapCatcher
+
             // 顶/底部渐变背景（锁定时隐藏）
             if !bridge.isLocked.wrappedValue {
                 topShadowGradient
@@ -221,6 +223,7 @@ struct UnifiedPlayerControlOverlay: View {
                         }
                     }
             )
+
             // 清晰度选择面板（右侧滑入）
             if showQualityPanel {
                 Color.black.opacity(0.001)
@@ -231,6 +234,7 @@ struct UnifiedPlayerControlOverlay: View {
                     .transition(.move(edge: .trailing).combined(with: .opacity))
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .animation(.easeInOut(duration: 0.3), value: showQualityPanel)
         // 双向同步 bridge.isMaskShow ↔ isMaskVisible
         .onChange(of: bridge.isMaskShow.wrappedValue) { _, newValue in
@@ -282,6 +286,23 @@ struct UnifiedPlayerControlOverlay: View {
     }
 
     // MARK: - Lock Button
+
+    private var playerTapCatcher: some View {
+        // Native player views can consume the first left click/tap before
+        // SwiftUI sees it. Keep a full-size hit layer above the drawable and
+        // below real controls so empty-space taps only toggle the overlay.
+        Color.black.opacity(0.001)
+            .ignoresSafeArea()
+            .contentShape(Rectangle())
+            .allowsHitTesting(!isPopupOpen)
+            .onTapGesture {
+                if isMaskVisible {
+                    isMaskVisible = false
+                } else {
+                    revealControls()
+                }
+            }
+    }
 
     private var lockButton: some View {
         VStack {
@@ -683,5 +704,13 @@ struct UnifiedPlayerControlOverlay: View {
     private func cancelAutoHideTimer() {
         autoHideTask?.cancel()
         autoHideTask = nil
+    }
+
+    private func revealControls() {
+        isMaskVisible = true
+        bridge.isMaskShow.wrappedValue = true
+        if !isPopupOpen {
+            startAutoHideTimer()
+        }
     }
 }

--- a/iOS/AngelLive/AngelLive/FullUI/Views/Setting/PlatformLoginWebSheet.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/Setting/PlatformLoginWebSheet.swift
@@ -240,17 +240,19 @@ struct PlatformLoginWebSheet: View {
         let loginFlow = entry.loginFlow
 
         currentWebView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
-            let filteredCookies = cookies.filter { cookie in
-                loginFlow.cookieDomains.contains { hint in
-                    cookie.domain.contains(hint)
-                }
-            }
+            let filteredCookies = PlatformCookieCollector.filteredCookies(
+                from: cookies,
+                loginFlow: loginFlow
+            )
 
-            let cookieString = makeCookieString(from: filteredCookies)
+            let cookieString = PlatformCookieCollector.cookieHeader(from: filteredCookies)
             guard !cookieString.isEmpty else { return }
-            guard containsAuthenticatedCookie(in: filteredCookies, loginFlow: loginFlow) else { return }
+            guard PlatformCookieCollector.containsAuthenticatedCookie(
+                in: filteredCookies,
+                loginFlow: loginFlow
+            ) else { return }
 
-            let signature = makeCookieSignature(from: filteredCookies)
+            let signature = PlatformCookieCollector.signature(from: filteredCookies)
 
             Task { @MainActor in
                 guard !isSavingCookie else { return }
@@ -271,7 +273,7 @@ struct PlatformLoginWebSheet: View {
         errorMessage = nil
         statusText = "检测到登录状态，正在保存..."
 
-        let uid = extractUID(from: cookies, loginFlow: entry.loginFlow)
+        let uid = PlatformCookieCollector.extractUID(from: cookies, loginFlow: entry.loginFlow)
         let shouldValidate = entry.auth?.supportsValidation ?? false
 
         let result = await PlatformSessionManager.shared.loginWithCookie(
@@ -309,41 +311,6 @@ struct PlatformLoginWebSheet: View {
         isSavingCookie = false
     }
 
-    // MARK: - Cookie 工具
-
-    private func containsAuthenticatedCookie(in cookies: [HTTPCookie], loginFlow: ManifestLoginFlow) -> Bool {
-        let names = Set(cookies.map(\.name))
-        return loginFlow.authSignalCookies.contains { names.contains($0) }
-    }
-
-    private func makeCookieSignature(from cookies: [HTTPCookie]) -> String {
-        cookies
-            .sorted(by: { $0.name < $1.name })
-            .map { "\($0.name)=\($0.value)" }
-            .joined(separator: ";")
-    }
-
-    private func makeCookieString(from cookies: [HTTPCookie]) -> String {
-        var deduplicated = [String: String]()
-        for cookie in cookies {
-            deduplicated[cookie.name] = cookie.value
-        }
-        return deduplicated
-            .sorted(by: { $0.key < $1.key })
-            .map { "\($0.key)=\($0.value)" }
-            .joined(separator: "; ")
-    }
-
-    private func extractUID(from cookies: [HTTPCookie], loginFlow: ManifestLoginFlow) -> String? {
-        let uidNames = loginFlow.uidCookieNames ?? ["DedeUserID", "uid", "user_id", "userId"]
-        for name in uidNames {
-            if let value = cookies.first(where: { $0.name == name })?.value, !value.isEmpty {
-                return value
-            }
-        }
-        return nil
-    }
-
     // MARK: - Actions
 
     private func prepareRelogin(entry: LoginPlatformEntry) async {
@@ -378,14 +345,14 @@ struct PlatformLoginWebSheet: View {
     @MainActor
     private func clearWebLoginData(for loginFlow: ManifestLoginFlow) async {
         let dataStore = WKWebsiteDataStore.default()
-        let domainHints = webDataDomainHints(for: loginFlow)
+        let domainHints = PlatformCookieCollector.domainHints(for: loginFlow)
         guard !domainHints.isEmpty else { return }
 
         await withCheckedContinuation { continuation in
             dataStore.httpCookieStore.getAllCookies { cookies in
                 let matchingCookies = cookies.filter { cookie in
                     domainHints.contains { hint in
-                        normalizedDomain(cookie.domain).contains(hint)
+                        PlatformCookieCollector.domainMatches(cookie.domain, hint: hint)
                     }
                 }
 
@@ -412,7 +379,7 @@ struct PlatformLoginWebSheet: View {
             dataStore.fetchDataRecords(ofTypes: dataTypes) { records in
                 let matchingRecords = records.filter { record in
                     domainHints.contains { hint in
-                        normalizedDomain(record.displayName).contains(hint)
+                        PlatformCookieCollector.domainMatches(record.displayName, hint: hint)
                     }
                 }
 
@@ -426,24 +393,6 @@ struct PlatformLoginWebSheet: View {
                 }
             }
         }
-    }
-
-    private func webDataDomainHints(for loginFlow: ManifestLoginFlow) -> [String] {
-        var hints = loginFlow.cookieDomains
-        if let host = URL(string: loginFlow.loginURL)?.host {
-            hints.append(host)
-        }
-        if let host = loginFlow.websiteHost {
-            hints.append(host)
-        }
-
-        return Array(Set(hints.map(normalizedDomain).filter { !$0.isEmpty }))
-    }
-
-    private func normalizedDomain(_ domain: String) -> String {
-        domain
-            .lowercased()
-            .trimmingCharacters(in: CharacterSet(charactersIn: ". "))
     }
 
     private func reloadLoginStatus() async {
@@ -481,13 +430,14 @@ private struct PlatformLoginWebView: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = WKWebsiteDataStore.default()
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
         webView.allowsBackForwardNavigationGestures = true
-        if let userAgent = loginFlow.userAgent {
-            webView.customUserAgent = userAgent
-        }
+        let userAgent = effectiveUserAgent
+        webView.customUserAgent = userAgent
 
         DispatchQueue.main.async {
             onWebViewCreated(webView)
@@ -495,9 +445,7 @@ private struct PlatformLoginWebView: UIViewRepresentable {
 
         if let url = URL(string: loginFlow.loginURL) {
             var request = URLRequest(url: url)
-            if let userAgent = loginFlow.userAgent {
-                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            }
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
             webView.load(request)
         }
         return webView
@@ -505,11 +453,45 @@ private struct PlatformLoginWebView: UIViewRepresentable {
 
     func updateUIView(_ uiView: WKWebView, context: Context) {}
 
-    final class Coordinator: NSObject, WKNavigationDelegate {
+    private var effectiveUserAgent: String {
+        let custom = loginFlow.userAgent?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let custom, !custom.isEmpty {
+            return custom
+        }
+        // Twitch 会拒绝不完整的 WKWebView UA；默认伪装成同内核的移动 Safari。
+        return "Mozilla/5.0 (iPhone; CPU iPhone OS 18_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Mobile/15E148 Safari/604.1"
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         let onNavigationStateChange: (String?, URL?, Bool) -> Void
 
         init(onNavigationStateChange: @escaping (String?, URL?, Bool) -> Void) {
             self.onNavigationStateChange = onNavigationStateChange
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            if navigationAction.targetFrame == nil {
+                webView.load(navigationAction.request)
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            // SOOP/Apple/Google 登录常用 window.open；在当前 WebView 内接管，避免按钮无响应。
+            guard navigationAction.targetFrame == nil else { return nil }
+            webView.load(navigationAction.request)
+            return nil
         }
 
         func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {

--- a/iOS/AngelLive/AngelLive/FullUI/Views/UIKit/ViewControllers/RoomListViewController.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/UIKit/ViewControllers/RoomListViewController.swift
@@ -73,7 +73,23 @@ class RoomListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleSOOPPreviewSnapshotUpdate(_:)),
+            name: .soopPreviewSnapshotDidUpdate,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleSOOPAdultRoomFilterUpdate(_:)),
+            name: .soopAdultRoomFilterDidUpdate,
+            object: nil
+        )
         loadData()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     override func viewDidLayoutSubviews() {
@@ -162,10 +178,14 @@ class RoomListViewController: UIViewController {
         guard let viewModel = viewModel else { return }
 
         let cacheKey = "\(mainCategoryIndex)-\(subCategoryIndex)"
-        rooms = viewModel.roomListCache[cacheKey] ?? []
+        let cachedRooms = viewModel.roomListCache[cacheKey] ?? []
+        rooms = viewModel.filteredRoomList(
+            mainCategoryIndex: mainCategoryIndex,
+            subCategoryIndex: subCategoryIndex
+        )
 
         // 如果缓存中没有数据，则加载
-        if rooms.isEmpty {
+        if cachedRooms.isEmpty {
             Task { @MainActor in
                 // 临时保存当前选择的索引
                 let oldMainIndex = viewModel.selectedMainCategoryIndex
@@ -234,8 +254,10 @@ class RoomListViewController: UIViewController {
 
     func updateRooms() {
         guard let viewModel = viewModel else { return }
-        let cacheKey = "\(mainCategoryIndex)-\(subCategoryIndex)"
-        rooms = viewModel.roomListCache[cacheKey] ?? []
+        rooms = viewModel.filteredRoomList(
+            mainCategoryIndex: mainCategoryIndex,
+            subCategoryIndex: subCategoryIndex
+        )
 
         // 检查是否有错误需要显示
         if let error = viewModel.roomError, rooms.isEmpty {
@@ -248,6 +270,28 @@ class RoomListViewController: UIViewController {
         // reloadData 后立刻 layoutIfNeeded,把 cells 注册进 visibleCells,
         // 否则 cv 在内容不足 + JX 嵌套场景下可能直到下次 layout pass 才注册,didSelectItemAt 失效。
         collectionView.layoutIfNeeded()
+    }
+
+    @objc private func handleSOOPPreviewSnapshotUpdate(_ notification: Notification) {
+        let cacheKey = "\(mainCategoryIndex)-\(subCategoryIndex)"
+        guard notification.userInfo?["cacheKey"] as? String == cacheKey else { return }
+
+        let visibleIndexPaths = collectionView.indexPathsForVisibleItems
+        if visibleIndexPaths.isEmpty {
+            collectionView.reloadData()
+        } else {
+            collectionView.reloadItems(at: visibleIndexPaths)
+        }
+    }
+
+    @objc private func handleSOOPAdultRoomFilterUpdate(_ notification: Notification) {
+        guard let source = notification.object as? PlatformDetailViewModel,
+              source === viewModel else { return }
+        if let notificationCacheKey = notification.userInfo?["cacheKey"] as? String {
+            let cacheKey = "\(mainCategoryIndex)-\(subCategoryIndex)"
+            guard notificationCacheKey == cacheKey else { return }
+        }
+        updateRooms()
     }
 
     // MARK: - Error Handling
@@ -349,6 +393,16 @@ extension RoomListViewController: UICollectionViewDataSource {
 
 extension RoomListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        // 只把滚动到的 SOOP 19+ 候选窗口交给 ViewModel 预加载;
+        // ViewModel 会记住已检测/已截图的 roomId,避免刷新列表时重复拉流截图。
+        if indexPath.item < rooms.count {
+            viewModel?.preloadSOOPAdultPreviewSnapshots(
+                around: rooms[indexPath.item],
+                mainCategoryIndex: mainCategoryIndex,
+                subCategoryIndex: subCategoryIndex
+            )
+        }
+
         // 加载更多逻辑
         let count = rooms.count
         if count > 0, indexPath.item == count - 1 {

--- a/iOS/AngelLive/AngelLive/FullUI/Views/UIKit/ViewControllers/SubCategoryViewController.swift
+++ b/iOS/AngelLive/AngelLive/FullUI/Views/UIKit/ViewControllers/SubCategoryViewController.swift
@@ -62,6 +62,32 @@ class SubCategoryViewController: UIViewController {
         return button
     }()
 
+    private lazy var adultFilterContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(AppConstants.Colors.primaryBackground)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private lazy var adultFilterControl: UISegmentedControl = {
+        let control = UISegmentedControl(items: SOOPAdultRoomFilter.allCases.map(\.title))
+        control.selectedSegmentIndex = viewModel?.soopAdultRoomFilter.rawValue ?? SOOPAdultRoomFilter.all.rawValue
+        control.selectedSegmentTintColor = UIColor(AppConstants.Colors.accent)
+        control.setTitleTextAttributes(
+            [.foregroundColor: UIColor(AppConstants.Colors.secondaryText)],
+            for: .normal
+        )
+        control.setTitleTextAttributes(
+            [.foregroundColor: UIColor.white],
+            for: .selected
+        )
+        control.addTarget(self, action: #selector(adultFilterChanged(_:)), for: .valueChanged)
+        control.translatesAutoresizingMaskIntoConstraints = false
+        return control
+    }()
+
+    private var adultFilterHeightConstraint: NSLayoutConstraint?
+
     // MARK: - Initialization
 
     init(viewModel: PlatformDetailViewModel, mainCategoryIndex: Int, navigationState: LiveRoomNavigationState, namespace: Namespace.ID, favoriteModel: AppFavoriteModel? = nil) {
@@ -92,7 +118,12 @@ class SubCategoryViewController: UIViewController {
 
         view.addSubview(subCategorySegmentedView)
         view.addSubview(manageButton)
+        view.addSubview(adultFilterContainerView)
+        adultFilterContainerView.addSubview(adultFilterControl)
         view.addSubview(listContainerView)
+
+        let adultFilterHeightConstraint = adultFilterContainerView.heightAnchor.constraint(equalToConstant: 0)
+        self.adultFilterHeightConstraint = adultFilterHeightConstraint
 
         NSLayoutConstraint.activate([
             // 子分类 SegmentedView
@@ -107,8 +138,18 @@ class SubCategoryViewController: UIViewController {
             manageButton.widthAnchor.constraint(equalToConstant: 30),
             manageButton.heightAnchor.constraint(equalToConstant: 30),
 
+            adultFilterContainerView.topAnchor.constraint(equalTo: subCategorySegmentedView.bottomAnchor),
+            adultFilterContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            adultFilterContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            adultFilterHeightConstraint,
+
+            adultFilterControl.leadingAnchor.constraint(equalTo: adultFilterContainerView.leadingAnchor, constant: 20),
+            adultFilterControl.trailingAnchor.constraint(equalTo: adultFilterContainerView.trailingAnchor, constant: -20),
+            adultFilterControl.centerYAnchor.constraint(equalTo: adultFilterContainerView.centerYAnchor),
+            adultFilterControl.heightAnchor.constraint(equalToConstant: 32),
+
             // 房间列表容器
-            listContainerView.topAnchor.constraint(equalTo: subCategorySegmentedView.bottomAnchor),
+            listContainerView.topAnchor.constraint(equalTo: adultFilterContainerView.bottomAnchor),
             listContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             listContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             listContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
@@ -116,6 +157,7 @@ class SubCategoryViewController: UIViewController {
 
         // 关联子分类 segmentedView 和容器
         subCategorySegmentedView.listContainer = listContainerView
+        updateAdultFilterVisibility()
     }
 
     func updateSubCategories() {
@@ -154,6 +196,7 @@ class SubCategoryViewController: UIViewController {
 
         subCategorySegmentedView.reloadData()
         listContainerView.reloadData()
+        updateAdultFilterVisibility()
 
         // 默认选中第一个
         if !subCategories.isEmpty {
@@ -218,6 +261,23 @@ class SubCategoryViewController: UIViewController {
         }
 
         navigationController?.pushViewController(managementVC, animated: true)
+    }
+
+    @objc private func adultFilterChanged(_ sender: UISegmentedControl) {
+        guard let viewModel,
+              let filter = SOOPAdultRoomFilter(rawValue: sender.selectedSegmentIndex) else { return }
+        viewModel.setSOOPAdultRoomFilter(filter)
+        viewModel.preloadInitialSOOPAdultPreviewSnapshots(
+            mainCategoryIndex: mainCategoryIndex,
+            subCategoryIndex: viewModel.selectedSubCategoryIndex
+        )
+    }
+
+    private func updateAdultFilterVisibility() {
+        let shouldShow = viewModel?.supportsSOOPAdultRoomFilter == true
+        adultFilterContainerView.isHidden = !shouldShow
+        adultFilterHeightConstraint?.constant = shouldShow ? 44 : 0
+        adultFilterControl.selectedSegmentIndex = viewModel?.soopAdultRoomFilter.rawValue ?? SOOPAdultRoomFilter.all.rawValue
     }
 
     // 查找指定类型的父控制器

--- a/macOS/AngelLiveMacOS/ViewModels/RoomInfoViewModel.swift
+++ b/macOS/AngelLiveMacOS/ViewModels/RoomInfoViewModel.swift
@@ -121,7 +121,11 @@ final class RoomInfoViewModel {
             self.playErrorMessage = "暂无可用的播放源"
             return
         }
-        self.changePlayUrl(cdnIndex: 0, urlIndex: 0)
+        let initialSelection = RoomPlaybackResolver.preferredInitialSelection(in: playArgs)
+        self.changePlayUrl(
+            cdnIndex: initialSelection?.cdnIndex ?? 0,
+            urlIndex: initialSelection?.qualityIndex ?? 0
+        )
 
         // 已成功获取到播放参数，标记已加载
         hasLoadedPlayURL = true

--- a/macOS/AngelLiveMacOS/Views/MacPlatformLoginWebSheet.swift
+++ b/macOS/AngelLiveMacOS/Views/MacPlatformLoginWebSheet.swift
@@ -122,9 +122,7 @@ struct MacPlatformLoginWebSheet: View {
 
             Section {
                 Button("重新登录") {
-                    showWebView = true
-                    statusText = "请在网页中完成登录，系统会自动保存会话并由宿主托管鉴权。"
-                    errorMessage = nil
+                    Task { await prepareRelogin(entry: entry) }
                 }
             } footer: {
                 Text("Cookie 过期或切换账号时点这里，会打开登录页重新抓取。")
@@ -230,6 +228,7 @@ struct MacPlatformLoginWebSheet: View {
 
     private func startCookiePolling(entry: LoginPlatformEntry) {
         cookiePollingTimer?.invalidate()
+        pollCookieOnce(entry: entry)
         cookiePollingTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { _ in
             pollCookieOnce(entry: entry)
         }
@@ -240,17 +239,19 @@ struct MacPlatformLoginWebSheet: View {
         let loginFlow = entry.loginFlow
 
         currentWebView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
-            let filteredCookies = cookies.filter { cookie in
-                loginFlow.cookieDomains.contains { hint in
-                    cookie.domain.contains(hint)
-                }
-            }
+            let filteredCookies = PlatformCookieCollector.filteredCookies(
+                from: cookies,
+                loginFlow: loginFlow
+            )
 
-            let cookieString = makeCookieString(from: filteredCookies)
+            let cookieString = PlatformCookieCollector.cookieHeader(from: filteredCookies)
             guard !cookieString.isEmpty else { return }
-            guard containsAuthenticatedCookie(in: filteredCookies, loginFlow: loginFlow) else { return }
+            guard PlatformCookieCollector.containsAuthenticatedCookie(
+                in: filteredCookies,
+                loginFlow: loginFlow
+            ) else { return }
 
-            let signature = makeCookieSignature(from: filteredCookies)
+            let signature = PlatformCookieCollector.signature(from: filteredCookies)
 
             Task { @MainActor in
                 guard !isSavingCookie else { return }
@@ -267,7 +268,7 @@ struct MacPlatformLoginWebSheet: View {
         errorMessage = nil
         statusText = "检测到登录状态，正在保存..."
 
-        let uid = extractUID(from: cookies, loginFlow: entry.loginFlow)
+        let uid = PlatformCookieCollector.extractUID(from: cookies, loginFlow: entry.loginFlow)
         let shouldValidate = entry.auth?.supportsValidation ?? false
 
         let result = await PlatformSessionManager.shared.loginWithCookie(
@@ -290,12 +291,15 @@ struct MacPlatformLoginWebSheet: View {
             }
             await reloadLoginStatus()
         case .expired:
+            isLoggedIn = false
             statusText = "登录信息已过期"
             errorMessage = "Cookie 已过期，请重新登录。"
         case .invalid(let reason):
+            isLoggedIn = false
             statusText = "登录信息无效"
             errorMessage = reason
         case .networkError(let message):
+            isLoggedIn = false
             statusText = "网络错误"
             errorMessage = message
         }
@@ -303,48 +307,26 @@ struct MacPlatformLoginWebSheet: View {
         isSavingCookie = false
     }
 
-    // MARK: - Cookie 工具
-
-    private func containsAuthenticatedCookie(in cookies: [HTTPCookie], loginFlow: ManifestLoginFlow) -> Bool {
-        let names = Set(cookies.map(\.name))
-        return loginFlow.authSignalCookies.contains { names.contains($0) }
-    }
-
-    private func makeCookieSignature(from cookies: [HTTPCookie]) -> String {
-        cookies
-            .sorted(by: { $0.name < $1.name })
-            .map { "\($0.name)=\($0.value)" }
-            .joined(separator: ";")
-    }
-
-    private func makeCookieString(from cookies: [HTTPCookie]) -> String {
-        var deduplicated = [String: String]()
-        for cookie in cookies {
-            deduplicated[cookie.name] = cookie.value
-        }
-        return deduplicated
-            .sorted(by: { $0.key < $1.key })
-            .map { "\($0.key)=\($0.value)" }
-            .joined(separator: "; ")
-    }
-
-    private func extractUID(from cookies: [HTTPCookie], loginFlow: ManifestLoginFlow) -> String? {
-        let uidNames = loginFlow.uidCookieNames ?? ["DedeUserID", "uid", "user_id", "userId"]
-        for name in uidNames {
-            if let value = cookies.first(where: { $0.name == name })?.value, !value.isEmpty {
-                return value
-            }
-        }
-        return nil
-    }
-
     // MARK: - Actions
+
+    private func prepareRelogin(entry: LoginPlatformEntry) async {
+        statusText = "正在清理网页登录缓存..."
+        errorMessage = nil
+        lastSavedCookieSignature = nil
+        currentWebView = nil
+        await clearWebLoginData(for: entry.loginFlow)
+        showWebView = true
+        statusText = "请在网页中完成登录，系统会自动保存会话并由宿主托管鉴权。"
+    }
 
     private func logout() {
         Task {
             await syncService.clearSession(pluginId: pluginId)
             if syncService.iCloudSyncEnabled {
                 await syncService.syncAllToICloud()
+            }
+            if let entry {
+                await clearWebLoginData(for: entry.loginFlow)
             }
             await MainActor.run {
                 isLoggedIn = false
@@ -354,6 +336,59 @@ struct MacPlatformLoginWebSheet: View {
                 showWebView = false
                 statusText = "已退出登录"
                 errorMessage = nil
+            }
+        }
+    }
+
+    @MainActor
+    private func clearWebLoginData(for loginFlow: ManifestLoginFlow) async {
+        let dataStore = WKWebsiteDataStore.default()
+        let domainHints = PlatformCookieCollector.domainHints(for: loginFlow)
+        guard !domainHints.isEmpty else { return }
+
+        await withCheckedContinuation { continuation in
+            dataStore.httpCookieStore.getAllCookies { cookies in
+                let matchingCookies = cookies.filter { cookie in
+                    domainHints.contains { hint in
+                        PlatformCookieCollector.domainMatches(cookie.domain, hint: hint)
+                    }
+                }
+
+                guard !matchingCookies.isEmpty else {
+                    continuation.resume()
+                    return
+                }
+
+                let group = DispatchGroup()
+                for cookie in matchingCookies {
+                    group.enter()
+                    dataStore.httpCookieStore.delete(cookie) {
+                        group.leave()
+                    }
+                }
+                group.notify(queue: .main) {
+                    continuation.resume()
+                }
+            }
+        }
+
+        let dataTypes = WKWebsiteDataStore.allWebsiteDataTypes()
+        await withCheckedContinuation { continuation in
+            dataStore.fetchDataRecords(ofTypes: dataTypes) { records in
+                let matchingRecords = records.filter { record in
+                    domainHints.contains { hint in
+                        PlatformCookieCollector.domainMatches(record.displayName, hint: hint)
+                    }
+                }
+
+                guard !matchingRecords.isEmpty else {
+                    continuation.resume()
+                    return
+                }
+
+                dataStore.removeData(ofTypes: dataTypes, for: matchingRecords) {
+                    continuation.resume()
+                }
             }
         }
     }
@@ -391,13 +426,14 @@ private struct MacPlatformLoginWebView: NSViewRepresentable {
     func makeNSView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = WKWebsiteDataStore.default()
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
 
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
+        webView.uiDelegate = context.coordinator
         webView.allowsBackForwardNavigationGestures = true
-        if let userAgent = loginFlow.userAgent {
-            webView.customUserAgent = userAgent
-        }
+        let userAgent = effectiveUserAgent
+        webView.customUserAgent = userAgent
 
         DispatchQueue.main.async {
             onWebViewCreated(webView)
@@ -405,9 +441,7 @@ private struct MacPlatformLoginWebView: NSViewRepresentable {
 
         if let url = URL(string: loginFlow.loginURL) {
             var request = URLRequest(url: url)
-            if let userAgent = loginFlow.userAgent {
-                request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-            }
+            request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
             webView.load(request)
         }
         return webView
@@ -415,11 +449,45 @@ private struct MacPlatformLoginWebView: NSViewRepresentable {
 
     func updateNSView(_ nsView: WKWebView, context: Context) {}
 
-    final class Coordinator: NSObject, WKNavigationDelegate {
+    private var effectiveUserAgent: String {
+        let custom = loginFlow.userAgent?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let custom, !custom.isEmpty {
+            return custom
+        }
+        // 保持 UA 与 WebKit 能力一致，避免 Twitch 等站点把登录页判成异常浏览器。
+        return "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15"
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
         let onNavigationStateChange: (String?, URL?, Bool) -> Void
 
         init(onNavigationStateChange: @escaping (String?, URL?, Bool) -> Void) {
             self.onNavigationStateChange = onNavigationStateChange
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        ) {
+            if navigationAction.targetFrame == nil {
+                webView.load(navigationAction.request)
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            // 第三方登录按钮经常开新窗口；复用当前 WebView，Cookie 仍留在同一 dataStore。
+            guard navigationAction.targetFrame == nil else { return nil }
+            webView.load(navigationAction.request)
+            return nil
         }
 
         func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {

--- a/macOS/AngelLiveMacOS/Views/PlatformDetailView.swift
+++ b/macOS/AngelLiveMacOS/Views/PlatformDetailView.swift
@@ -26,9 +26,9 @@ struct PlatformDetailView: View {
         return "加载失败-请登录\(platformName)账号"
     }
 
-    /// 根据平台类型显示对应的登录视图
+    /// 平台登录注册表按 pluginId 建索引，不能用 liveType rawValue。
     private var platformLoginView: some View {
-        MacPlatformLoginWebSheet(pluginId: viewModel.platform.liveType.rawValue)
+        MacPlatformLoginWebSheet(pluginId: viewModel.platform.pluginId)
             .frame(minWidth: 800, minHeight: 600)
     }
 
@@ -407,7 +407,7 @@ struct LiveRoomCard: View {
 //    }
 
     private var coverURL: URL? {
-        guard !room.roomCover.isEmpty, let url = URL(string: room.roomCover) else { return nil }
+        guard !room.displayRoomCover.isEmpty, let url = URL(string: room.displayRoomCover) else { return nil }
         return url
     }
 
@@ -437,7 +437,7 @@ struct LiveRoomCard: View {
                 .clipShape(RoundedRectangle(cornerRadius: AppConstants.CornerRadius.lg))
 
             HStack(spacing: 8) {
-                RemoteAvatarView(url: URL(string: room.userHeadImg), size: 32) {
+                RemoteAvatarView(url: URL(string: room.displayUserHeadImg), size: 32) {
                     Circle()
                         .fill(Color.gray.opacity(0.3))
                 }

--- a/macOS/AngelLiveMacOS/Views/PlayerControlView.swift
+++ b/macOS/AngelLiveMacOS/Views/PlayerControlView.swift
@@ -385,7 +385,7 @@ struct PlayerControlView: View {
     private var streamerInfoCard: some View {
         HStack(spacing: 10) {
             // 主播头像
-            RemoteAvatarView(url: URL(string: room.userHeadImg), size: 36) {
+            RemoteAvatarView(url: URL(string: room.displayUserHeadImg), size: 36) {
                 Circle()
                     .fill(Color.gray.opacity(0.3))
             }


### PR DESCRIPTION
# SimpleLiveTVOS 修复变更说明（ops4.7 审查版）

日期：2026-05-16

## 本次重点

本 PR 主要修复三类线上可见问题：

- Twitch / Kick / SOOP 的 Cookie 登录与宿主登录入口兼容。
- CHZZK 默认进入低清晰度或 Auto 的问题。
- SOOP 登录后部分直播间，尤其 19x 直播间，预览图、播放控制和筛选体验异常。

真机回归过程中额外修复：

- Twitch 1.0.31 分类列表加载失败，报 `missing clientId or accessToken in token server response`。
- 个人开发签名不包含 iCloud entitlement 时 App 启动或同步入口崩溃。
- 官方订阅密钥 `444222000` 未稳定解析。

## 关键修复

### 1. 平台登录和 Cookie

- 新增宿主侧登录兼容层，旧 manifest 未声明 `loginFlow` 时，Twitch / Kick / SOOP 仍能进入账号管理和 Web 登录。
- iOS / macOS 登录面板统一使用 `PlatformCookieCollector` 收集、过滤、去重 Cookie。
- Web 登录页清理站点数据后再重新登录，避免旧 Cookie 干扰。
- iOS 登录 WebView 改为移动 Safari 风格 UA，避免 Twitch 提示“不支持您的浏览器”。
- iOS / macOS 都接管 `target=_blank` / `window.open`，SOOP 的 Apple / Google 登录按钮可以在当前 WebView 内跳转。
- manifest 显式声明 `auth.required=false` 时优先于宿主 fallback，避免以后插件作者显式开放匿名模式时被宿主覆盖。

### 2. Twitch 1.0.31 列表加载

- `twitch@1.0.31` 发布说明是 website GQL，但导出的 `getCategories` / `getRooms` 仍走 Helix token server。
- 当 token server 返回缺少 `clientId/accessToken` 时，平台页会直接加载失败。
- 新增 `LiveParsePluginCompatibilityPatch`，只对 `twitch@1.0.31` 注入兼容脚本。
- 兼容脚本复用插件内已有的 `_tw_fetchTopGames`、`_tw_fetchAllStreamsPage`、`_tw_fetchCategoryStreamsPage`，把分类和直播间列表切回 `https://gql.twitch.tv/gql`。
- 兼容 Twitch 分类 URL 的 slug，例如 `just-chatting` 会解析回游戏 ID `509658`，并按房间 `biz` 再做一次分类过滤。
- 即使宿主路径传入 `id=root`，也会优先读取 `category.id/category.biz` 中的真实分类。
- 补丁按精确版本命中，后续上游插件升级到 1.0.32 或其它版本时自动停止注入。

### 3. CHZZK 默认清晰度

- 新增 `RoomPlaybackResolver.preferredInitialSelection(in:)`。
- 默认播放不再盲选插件返回的第一项，而是按可播放性和清晰度评分选择初始项。
- 明确分辨率优先于 Auto / 自适应。
- Source / Best / 原画优先级最高，但空 URL 占位项不会抢默认播放。
- audio-only 音频轨不参与默认视频清晰度竞争。
- iOS / tvOS / macOS 三端接入同一选择逻辑，tvOS 展示标题也与 iOS / macOS 对齐。

### 4. SOOP 预览图和 19x

- 新增 `LiveImageURLResolver`，统一标准化封面和头像 URL。
- SOOP 空封面且 `roomId` 为数字时兜底到 `https://liveimg.sooplive.com/m/{roomId}?320`。
- SOOP 旧图床域名和 http 链接统一 canonicalize，减少 Kingfisher / ATS 加载失败。
- 19x 灰色年龄占位图通过封面 CDN 内容长度识别。
- 只有识别为 19x 占位图的房间才解析播放地址并截取首帧；非 19x 不做实时刷新。
- 19x 实时封面只写入 Kingfisher 内存缓存，key 保持稳定，不污染收藏、历史或 CloudKit 持久化字段。
- 首次进入 SOOP 会预取前三页并预热 19x 封面；向下滚动时继续预加载新出现的 19x 房间。
- 已检测或已加载过的房间不会因为下拉刷新、点击刷新或切换筛选重复拉流截图。
- iOS SOOP 分类页新增筛选：`全部 / 19x / 非19x`。

### 5. SOOP 19x 播放控制

- 移除 VLC drawable 上的 SwiftUI `onTapGesture`，避免 19x 流播放时点击事件和 VLCKit drawable 抢占。
- 控制层改用全屏透明 tap catcher：隐藏时点击显示，显示时点击空白处隐藏。
- VLC 同一 media fingerprint 下不再从 `.paused` 强行恢复播放，只处理 `.stopped` / `.error` 恢复。
- stop / media 释放移到后台队列，降低主线程卡顿和闪退风险。

### 6. 真机签名和订阅源

- 新增 `CloudKitContainerAccess`，访问命名 CloudKit 容器前先检查当前签名是否包含目标 iCloud 容器。
- 个人开发团队不支持 iCloud / Push 时，本地 Debug 包跳过 CloudKit 同步，不再在 `CKContainer(identifier:)` 崩溃。
- 收藏、书签、插件源同步、平台凭证同步都接入该 guard。
- `PluginSourceKeyService` 补齐官方 `keys.json` 地址，并内置 `444222000` 兜底映射。

## 主要文件

新增：

- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginCompatibility.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformCookieCollector.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/LiveImageURLResolver.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/CloudKitContainerAccess.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParsePluginCompatibilityPatch.swift`

重点修改：

- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/JSRuntime.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/Plugin/LiveParseLoadedPlugin.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/LiveParse/LiveParseJSPlatformManager.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Playback/RoomPlaybackResolver.swift`
- `Shared/AngelLiveCore/Sources/AngelLiveCore/Services/PlatformLoginRegistry.swift`
- `iOS/AngelLive/AngelLive/FullUI/ViewModels/PlatformDetailViewModel.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/UIKit/ViewControllers/RoomListViewController.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/UIKit/ViewControllers/SubCategoryViewController.swift`
- `iOS/AngelLive/AngelLive/FullUI/Views/Setting/PlatformLoginWebSheet.swift`
- `macOS/AngelLiveMacOS/Views/MacPlatformLoginWebSheet.swift`
- `macOS/AngelLiveMacOS/Views/PlatformDetailView.swift`
- 三端 `RoomInfoViewModel`

## 测试覆盖

新增或更新的 Core 测试覆盖：

- Twitch / Kick / SOOP 旧 manifest 登录 fallback。
- manifest 显式 `auth.required=false` 优先于宿主 fallback。
- Cookie 跨域过滤、登录信号识别和 session Cookie 去重优先级。
- 官方订阅密钥 `444222000` 兜底解析。
- SOOP 封面 URL 标准化和空封面兜底。
- CHZZK 类清晰度列表默认选择 1080p，跳过 Auto、空 URL 占位和 audio-only。
- `twitch@1.0.31` 兼容脚本只命中该版本，并可在宿主 JavaScriptCore 中执行。
- Twitch `just-chatting` slug 能解析到 `509658`，且只返回该分类房间。
- Twitch 分类 URL 在 `id=root` 的兜底路径下也能解析到 `509658`。

## 兼容边界

- 登录兼容层只作为旧 manifest 兜底；插件 manifest 明确声明时优先使用插件声明。
- Twitch 列表补丁只作用于 `twitch@1.0.31`。
- SOOP 19x 实时封面只在 iOS 列表层启用。
- 非 19x SOOP 房间不做实时截图、不强制刷新封面。
- SOOP 19x 截图只进内存缓存，不写入收藏、历史、CloudKit。
- CHZZK 清晰度修复只改变初始默认项，不改变用户手动切换流程。
- 缺少 iCloud entitlement 时只跳过 CloudKit 同步，本地功能继续可用。

## 验证结果

已执行：

```bash
git diff --check
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --package-path Shared/AngelLiveCore
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer USE_VLC=1 xcodebuild build -workspace AngelLive.xcworkspace -scheme AngelLive -configuration Debug -destination 'platform=iOS,id=00008130-000204881E6A001C' -allowProvisioningUpdates -skipPackagePluginValidation -quiet
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device install app --device 6F726895-0F44-53B8-9291-C68C6C5B11A2 /Users/bing/Library/Developer/Xcode/DerivedData/AngelLive-gcijnxzpyclukqgalnuqneqbaqcp/Build/Products/Debug-iphoneos/AngelLive.app
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun devicectl device process launch --device 6F726895-0F44-53B8-9291-C68C6C5B11A2 --terminate-existing --console com.anlonely.AngelLiveTest
```

结果：

- Core 测试通过：`35 tests passed`。
- iOS 26.1 真机 Debug 构建、安装、启动通过。
- 个人开发签名无 iCloud entitlement 时可正常进入 App。
- 输入订阅密钥 `444222000` 后可安装官方插件。
- SOOP 19x 播放控制真机复测：点击画面可弹出控制层，不再持续闪烁或卡死。
- SOOP 19x 实时封面真机日志确认写入稳定 key：`https://liveimg.sooplive.com/m/{roomId}?320`。
- Twitch 1.0.31 真机日志确认 `getCategories` / `getRooms` 均请求 `https://gql.twitch.tv/gql`，HTTP 200，分类和直播间列表成功返回。

## 建议重点审查

- `LiveParsePluginCompatibilityPatch` 的 Twitch 版本边界是否足够保守。
- `RoomPlaybackResolver.preferredInitialSelection` 是否符合 CHZZK 当前插件返回结构。
- `PlatformCookieCollector` 的 Cookie 域匹配和 session Cookie 优先级。
- SOOP 19x 筛选中“未知状态不进入 19x / 非19x结果”的产品语义。
- SOOP 19x 实时封面只写内存缓存、不污染持久化字段的策略是否符合发布预期。
